### PR TITLE
fix: return FT metadata in a backwards compatible way

### DIFF
--- a/src/api/routes/ft.ts
+++ b/src/api/routes/ft.ts
@@ -44,6 +44,11 @@ export const FtRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeB
           decimals: metadataBundle?.token?.decimals ?? undefined,
           total_supply: metadataBundle?.token?.total_supply?.toString() ?? undefined,
           token_uri: metadataBundle?.token?.uri ?? undefined,
+          description: metadataBundle?.metadataLocale?.metadata?.description ?? undefined,
+          tx_id: metadataBundle?.smartContract.tx_id,
+          sender_address: metadataBundle?.smartContract.principal.split('.')[0],
+          image_uri: metadataBundle?.metadataLocale?.metadata?.cached_image ?? undefined,
+          image_canonical_uri: metadataBundle?.metadataLocale?.metadata?.image ?? undefined,
           metadata: parseMetadataLocaleBundle(metadataBundle?.metadataLocale),
         });
       } catch (error) {

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -118,28 +118,28 @@ export const MetadataLocalization = Type.Object({
   locales: Type.Array(Type.String(), { examples: [['en', 'jp']] }),
 });
 
+const TokenDescription = Type.String({
+  examples: [
+    'Heavy hitters, all-stars and legends of the game join forces to create a collection of unique varsity jackets',
+  ],
+});
+
+const TokenImage = Type.String({
+  format: 'uri',
+  examples: ['ipfs://ipfs/QmZMqhh2ztwuZ3Y8PyEp2z5auyH3TCm3nnr5ZfjjgDjd5q/12199.png'],
+});
+
+const TokenCachedImage = Type.String({
+  format: 'uri',
+  examples: ['https://ipfs.io/ipfs/QmZMqhh2ztwuZ3Y8PyEp2z5auyH3TCm3nnr5ZfjjgDjd5q/12199.png'],
+});
+
 export const Metadata = Type.Object({
   sip: Type.Integer({ examples: [16] }),
   name: Type.Optional(Type.String({ examples: ["Satoshi's Team #12200"] })),
-  description: Type.Optional(
-    Type.String({
-      examples: [
-        'Heavy hitters, all-stars and legends of the game join forces to create a collection of unique varsity jackets',
-      ],
-    })
-  ),
-  image: Type.Optional(
-    Type.String({
-      format: 'uri',
-      examples: ['ipfs://ipfs/QmZMqhh2ztwuZ3Y8PyEp2z5auyH3TCm3nnr5ZfjjgDjd5q/12199.png'],
-    })
-  ),
-  cached_image: Type.Optional(
-    Type.String({
-      format: 'uri',
-      examples: ['https://ipfs.io/ipfs/QmZMqhh2ztwuZ3Y8PyEp2z5auyH3TCm3nnr5ZfjjgDjd5q/12199.png'],
-    })
-  ),
+  description: Type.Optional(TokenDescription),
+  image: Type.Optional(TokenImage),
+  cached_image: Type.Optional(TokenCachedImage),
   attributes: Type.Optional(Type.Array(MetadataAttribute)),
   properties: Type.Optional(MetadataProperties),
   localization: Type.Optional(MetadataLocalization),
@@ -167,6 +167,13 @@ export const FtMetadataResponse = Type.Object({
   decimals: Type.Optional(Type.Integer({ examples: [8] })),
   total_supply: Type.Optional(Type.String({ examples: ['9999980000000'] })),
   token_uri: Type.Optional(TokenUri),
+  description: Type.Optional(TokenDescription),
+  image_uri: Type.Optional(TokenCachedImage),
+  image_canonical_uri: Type.Optional(TokenImage),
+  tx_id: Type.String({
+    examples: ['0xef2ac1126e16f46843228b1dk4830e19eb7599129e4jf392cab9e65ae83a45c0'],
+  }),
+  sender_address: Type.String({ examples: ['ST399W7Z9WS0GMSNQGJGME5JAENKN56D65VGMGKGA'] }),
   metadata: Type.Optional(Metadata),
 });
 

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -151,7 +151,11 @@ export class PgStore extends BasePgStore {
       if (args.locale && !(await this.isTokenLocaleAvailable(tokenIdRes[0].id, args.locale))) {
         throw new TokenLocaleNotFoundError();
       }
-      return await this.getTokenMetadataBundleInternal(tokenIdRes[0].id, args.locale);
+      return await this.getTokenMetadataBundleInternal(
+        tokenIdRes[0].id,
+        args.contractPrincipal,
+        args.locale
+      );
     });
   }
 
@@ -442,6 +446,7 @@ export class PgStore extends BasePgStore {
 
   private async getTokenMetadataBundleInternal(
     tokenId: number,
+    smartContractPrincipal: string,
     locale?: string
   ): Promise<DbTokenMetadataLocaleBundle> {
     const tokenRes = await this.sql<DbToken[]>`
@@ -477,8 +482,13 @@ export class PgStore extends BasePgStore {
         properties: properties,
       };
     }
+    const smartContract = await this.getSmartContract({ principal: smartContractPrincipal });
+    if (!smartContract) {
+      throw new TokenNotFoundError();
+    }
     return {
-      token: token,
+      token,
+      smartContract,
       metadataLocale: localeBundle,
     };
   }

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -40,7 +40,6 @@ export type DbSmartContract = {
   id: number;
   principal: string;
   sip: DbSipNumber;
-  abi: string;
   tx_id: string;
   block_height: number;
   token_count?: bigint;
@@ -188,6 +187,7 @@ export type DbMetadataLocaleBundle = {
 
 export type DbTokenMetadataLocaleBundle = {
   token: DbToken;
+  smartContract: DbSmartContract;
   metadataLocale?: DbMetadataLocaleBundle;
 };
 
@@ -195,7 +195,6 @@ export const SMART_CONTRACTS_COLUMNS = [
   'id',
   'principal',
   'sip',
-  'abi',
   'tx_id',
   'block_height',
   'token_count',

--- a/tests/ft.test.ts
+++ b/tests/ft.test.ts
@@ -117,6 +117,8 @@ describe('FT routes', () => {
       symbol: 'HELLO',
       token_uri: 'http://test.com/uri.json',
       total_supply: '1',
+      sender_address: 'SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS',
+      tx_id: '0x123456',
     });
   });
 
@@ -182,6 +184,11 @@ describe('FT routes', () => {
       token_uri: 'http://test.com/uri.json',
       total_supply: '1',
       decimals: 6,
+      sender_address: 'SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS',
+      tx_id: '0x123456',
+      description: 'test',
+      image_canonical_uri: 'http://test.com/image.png',
+      image_uri: 'http://test.com/image.png?processed=true',
       metadata: {
         sip: 16,
         description: 'test',


### PR DESCRIPTION
This PR makes the FT response be backwards-compatible to the current Stacks API FT response, so we can set up a simple redirect/rewrite from there to this new API immediately.

Example old Stacks API FT response:
```json
{
  "token_uri": "https://heystack.xyz/token-metadata.json",
  "name": "Heystack",
  "description": "Heystack is a SIP-010-compliant fungible token on the Stacks Blockchain, used on the Heystack app",
  "image_uri": "https://heystack.xyz/assets/Stacks128w.png",
  "image_canonical_uri": "https://heystack.xyz/assets/Stacks128w.png",
  "tx_id": "0xef2ac1126e16f46843228b1dk4830e19eb7599129e4jf392cab9e65ae83a45c0",
  "sender_address": "ST399W7Z9WS0GMSNQGJGME5JAENKN56D65VGMGKGA",
  "symbol": "HEY",
  "decimals": 5
}
```

New FT response: https://token-metadata-csgxi67fv-blockstack.vercel.app/#tag/Tokens/operation/getFtMetadata