### PR TITLE
fix: do not retry incorrect clarity values

### DIFF
--- a/src/token-processor/stacks-node/stacks-node-rpc-client.ts
+++ b/src/token-processor/stacks-node/stacks-node-rpc-client.ts
@@ -128,7 +128,7 @@ export class StacksNodeRpcClient {
     if (unwrappedClarityValue.type_id === ClarityTypeID.UInt) {
       return unwrappedClarityValue;
     }
-    throw new RetryableJobError(
+    throw new Error(
       `Unexpected Clarity type '${unwrappedClarityValue.type_id}' while unwrapping uint`
     );
   }
@@ -143,7 +143,7 @@ export class StacksNodeRpcClient {
     } else if (unwrappedClarityValue.type_id === ClarityTypeID.OptionalNone) {
       return undefined;
     }
-    throw new RetryableJobError(
+    throw new Error(
       `Unexpected Clarity type '${unwrappedClarityValue.type_id}' while unwrapping string`
     );
   }

--- a/tests/stacks-node-rpc-client.test.ts
+++ b/tests/stacks-node-rpc-client.test.ts
@@ -113,7 +113,7 @@ describe('StacksNodeRpcClient', () => {
     }
   });
 
-  test('clarity value parse errors get retried', async () => {
+  test('clarity value parse errors are not retried', async () => {
     const mockResponse = {
       okay: true,
       result: cvToHex(uintCV(5)), // `get-token-uri` will fail because this is a `uint`
@@ -129,9 +129,7 @@ describe('StacksNodeRpcClient', () => {
       .reply(200, mockResponse);
     setGlobalDispatcher(agent);
 
-    await expect(client.readStringFromContract('get-token-uri', [])).rejects.toThrow(
-      RetryableJobError
-    );
+    await expect(client.readStringFromContract('get-token-uri', [])).rejects.toThrow(Error);
   });
 
   test('incorrect none uri strings are parsed as undefined', async () => {


### PR DESCRIPTION
A few contracts are creating an infinite loop of retries because some of their functions don't conform to SIP-010. For example, `SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-wxusd` returns this for `get-total-supply` which according to SIP-010 should always be `uint`.
```clarity
;; @desc get-total-supply
;; @returns (response uint)
(define-read-only (get-total-supply)
  ;; least authority Issue D
  ERR-NOT-SUPPORTED
)
```
For now, this PR avoids retrying indefinitely in these cases. In the future we could relax these restrictions and mark those fields as `undefined`