### PR TITLE
feat: add `invalid` job status to mark invalid contracts or tokens

### DIFF
--- a/migrations/1679941023060_add-invalid-job-status.ts
+++ b/migrations/1679941023060_add-invalid-job-status.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addTypeValue('job_status', 'invalid');
+}
+
+export function down(pgm: MigrationBuilder): void {}

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -158,6 +158,13 @@ export const TokenNotFoundResponse = Type.Object(
   { title: 'Token Not Found Response' }
 );
 
+export const ContractNotFoundResponse = Type.Object(
+  {
+    error: Type.Literal('Contract not found'),
+  },
+  { title: 'Contract Not Found Response' }
+);
+
 export const TokenNotProcessedResponse = Type.Object(
   {
     error: Type.Literal('Token metadata fetch in progress'),
@@ -186,14 +193,18 @@ export const InvalidTokenMetadataResponse = Type.Object(
   { title: 'Invalid Token Metadata Response' }
 );
 
-export const TokenErrorResponse = Type.Union(
+export const NotFoundResponse = Type.Union([TokenNotFoundResponse, ContractNotFoundResponse], {
+  title: 'Not Found Error Response',
+});
+
+export const ErrorResponse = Type.Union(
   [
     TokenNotProcessedResponse,
     TokenLocaleNotFoundResponse,
     InvalidTokenContractResponse,
     InvalidTokenMetadataResponse,
   ],
-  { title: 'Token Error Response' }
+  { title: 'Error Response' }
 );
 
 export const FtMetadataResponse = Type.Object(

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -172,8 +172,27 @@ export const TokenLocaleNotFoundResponse = Type.Object(
   { title: 'Locale Not Found Response' }
 );
 
+export const InvalidTokenContractResponse = Type.Object(
+  {
+    error: Type.Literal('Token contract is invalid or does not conform to its token standard'),
+  },
+  { title: 'Invalid Token Contract Response' }
+);
+
+export const InvalidTokenMetadataResponse = Type.Object(
+  {
+    error: Type.Literal('Token metadata is unreachable or does not conform to SIP-016'),
+  },
+  { title: 'Invalid Token Metadata Response' }
+);
+
 export const TokenErrorResponse = Type.Union(
-  [TokenNotProcessedResponse, TokenLocaleNotFoundResponse],
+  [
+    TokenNotProcessedResponse,
+    TokenLocaleNotFoundResponse,
+    InvalidTokenContractResponse,
+    InvalidTokenMetadataResponse,
+  ],
   { title: 'Token Error Response' }
 );
 

--- a/src/api/util/errors.ts
+++ b/src/api/util/errors.ts
@@ -3,12 +3,15 @@ import { FastifyReply } from 'fastify';
 import {
   InvalidTokenContractResponse,
   InvalidTokenMetadataResponse,
-  TokenErrorResponse,
+  ErrorResponse,
   TokenLocaleNotFoundResponse,
   TokenNotFoundResponse,
   TokenNotProcessedResponse,
+  NotFoundResponse,
+  ContractNotFoundResponse,
 } from '../schemas';
 import {
+  ContractNotFoundError,
   InvalidContractError,
   InvalidTokenError,
   TokenLocaleNotFoundError,
@@ -18,14 +21,16 @@ import {
 import { setReplyNonCacheable } from './cache';
 
 export const TokenErrorResponseSchema = {
-  404: TokenNotFoundResponse,
-  422: TokenErrorResponse,
+  404: NotFoundResponse,
+  422: ErrorResponse,
 };
 
 export async function generateTokenErrorResponse(error: any, reply: FastifyReply) {
   setReplyNonCacheable(reply);
   if (error instanceof TokenNotFoundError) {
     await reply.code(404).send(Value.Create(TokenNotFoundResponse));
+  } else if (error instanceof ContractNotFoundError) {
+    await reply.code(404).send(Value.Create(ContractNotFoundResponse));
   } else if (error instanceof TokenNotProcessedError) {
     await reply.code(422).send(Value.Create(TokenNotProcessedResponse));
   } else if (error instanceof TokenLocaleNotFoundError) {

--- a/src/api/util/errors.ts
+++ b/src/api/util/errors.ts
@@ -1,12 +1,16 @@
 import { Value } from '@sinclair/typebox/value';
 import { FastifyReply } from 'fastify';
 import {
+  InvalidTokenContractResponse,
+  InvalidTokenMetadataResponse,
   TokenErrorResponse,
   TokenLocaleNotFoundResponse,
   TokenNotFoundResponse,
   TokenNotProcessedResponse,
 } from '../schemas';
 import {
+  InvalidContractError,
+  InvalidTokenError,
   TokenLocaleNotFoundError,
   TokenNotFoundError,
   TokenNotProcessedError,
@@ -26,6 +30,10 @@ export async function generateTokenErrorResponse(error: any, reply: FastifyReply
     await reply.code(422).send(Value.Create(TokenNotProcessedResponse));
   } else if (error instanceof TokenLocaleNotFoundError) {
     await reply.code(422).send(Value.Create(TokenLocaleNotFoundResponse));
+  } else if (error instanceof InvalidContractError) {
+    await reply.code(422).send(Value.Create(InvalidTokenContractResponse));
+  } else if (error instanceof InvalidTokenError) {
+    await reply.code(422).send(Value.Create(InvalidTokenMetadataResponse));
   } else {
     throw error;
   }

--- a/src/pg/errors.ts
+++ b/src/pg/errors.ts
@@ -18,3 +18,17 @@ export class TokenLocaleNotFoundError extends Error {
     this.name = this.constructor.name;
   }
 }
+
+export class InvalidContractError extends Error {
+  constructor() {
+    super();
+    this.name = this.constructor.name;
+  }
+}
+
+export class InvalidTokenError extends Error {
+  constructor() {
+    super();
+    this.name = this.constructor.name;
+  }
+}

--- a/src/pg/errors.ts
+++ b/src/pg/errors.ts
@@ -5,6 +5,13 @@ export class TokenNotFoundError extends Error {
   }
 }
 
+export class ContractNotFoundError extends Error {
+  constructor() {
+    super();
+    this.name = this.constructor.name;
+  }
+}
+
 export class TokenNotProcessedError extends Error {
   constructor() {
     super();

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -28,6 +28,7 @@ import {
 import { connectPostgres } from './postgres-tools';
 import { BasePgStore } from './postgres-tools/base-pg-store';
 import {
+  ContractNotFoundError,
   InvalidContractError,
   InvalidTokenError,
   TokenLocaleNotFoundError,
@@ -152,7 +153,7 @@ export class PgStore extends BasePgStore {
         WHERE smart_contracts.principal = ${args.contractPrincipal}
       `;
       if (contractJobStatus.count === 0) {
-        throw new TokenNotFoundError();
+        throw new ContractNotFoundError();
       }
       if (contractJobStatus[0].status === DbJobStatus.invalid) {
         throw new InvalidContractError();
@@ -518,7 +519,7 @@ export class PgStore extends BasePgStore {
     }
     const smartContract = await this.getSmartContract({ principal: smartContractPrincipal });
     if (!smartContract) {
-      throw new TokenNotFoundError();
+      throw new ContractNotFoundError();
     }
     return {
       token,

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -27,7 +27,13 @@ import {
 } from './types';
 import { connectPostgres } from './postgres-tools';
 import { BasePgStore } from './postgres-tools/base-pg-store';
-import { TokenLocaleNotFoundError, TokenNotFoundError, TokenNotProcessedError } from './errors';
+import {
+  InvalidContractError,
+  InvalidTokenError,
+  TokenLocaleNotFoundError,
+  TokenNotFoundError,
+  TokenNotProcessedError,
+} from './errors';
 import { runMigrations } from './migrations';
 
 /**
@@ -138,6 +144,20 @@ export class PgStore extends BasePgStore {
     locale?: string;
   }): Promise<DbTokenMetadataLocaleBundle> {
     return await this.sqlTransaction(async sql => {
+      // Is the contract invalid?
+      const contractJobStatus = await sql<{ status: DbJobStatus }[]>`
+        SELECT status
+        FROM jobs
+        INNER JOIN smart_contracts ON jobs.smart_contract_id = smart_contracts.id
+        WHERE smart_contracts.principal = ${args.contractPrincipal}
+      `;
+      if (contractJobStatus.count === 0) {
+        throw new TokenNotFoundError();
+      }
+      if (contractJobStatus[0].status === DbJobStatus.invalid) {
+        throw new InvalidContractError();
+      }
+      // Get token id
       const tokenIdRes = await sql<{ id: number }[]>`
         SELECT tokens.id
         FROM tokens
@@ -148,11 +168,14 @@ export class PgStore extends BasePgStore {
       if (tokenIdRes.count === 0) {
         throw new TokenNotFoundError();
       }
-      if (args.locale && !(await this.isTokenLocaleAvailable(tokenIdRes[0].id, args.locale))) {
+      const tokenId = tokenIdRes[0].id;
+      // Is the locale valid?
+      if (args.locale && !(await this.isTokenLocaleAvailable(tokenId, args.locale))) {
         throw new TokenLocaleNotFoundError();
       }
+      // Get metadata
       return await this.getTokenMetadataBundleInternal(
-        tokenIdRes[0].id,
+        tokenId,
         args.contractPrincipal,
         args.locale
       );
@@ -449,23 +472,27 @@ export class PgStore extends BasePgStore {
     smartContractPrincipal: string,
     locale?: string
   ): Promise<DbTokenMetadataLocaleBundle> {
+    // Is token invalid?
+    const tokenJobStatus = await this.sql<{ status: string }[]>`
+      SELECT status FROM jobs WHERE token_id = ${tokenId}
+    `;
+    if (tokenJobStatus.count === 0) {
+      throw new TokenNotFoundError();
+    }
+    const status = tokenJobStatus[0].status;
+    if (status === DbJobStatus.invalid) {
+      throw new InvalidTokenError();
+    }
+    // Get token
     const tokenRes = await this.sql<DbToken[]>`
       SELECT ${this.sql(TOKENS_COLUMNS)} FROM tokens WHERE id = ${tokenId}
     `;
-    if (tokenRes.count === 0) {
-      throw new TokenNotFoundError();
-    }
     const token = tokenRes[0];
-    // Is this token still waiting to be processed?
-    if (!token.updated_at) {
-      const tokenJobStatus = await this.sql<{ status: string }[]>`
-        SELECT status FROM jobs WHERE token_id = ${token.id}
-      `;
-      const status = tokenJobStatus[0].status;
-      if (status === DbJobStatus.queued || status === DbJobStatus.pending) {
-        throw new TokenNotProcessedError();
-      }
+    // Is it still waiting to be processed?
+    if (!token.updated_at && (status === DbJobStatus.queued || status === DbJobStatus.pending)) {
+      throw new TokenNotProcessedError();
     }
+    // Get metadata
     let localeBundle: DbMetadataLocaleBundle | undefined;
     const metadataRes = await this.sql<DbMetadata[]>`
       SELECT ${this.sql(METADATA_COLUMNS)} FROM metadata

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -14,6 +14,7 @@ export enum DbJobStatus {
   queued = 'queued',
   done = 'done',
   failed = 'failed',
+  invalid = 'invalid',
 }
 
 export enum DbTokenType {

--- a/src/token-processor/stacks-node/stacks-node-rpc-client.ts
+++ b/src/token-processor/stacks-node/stacks-node-rpc-client.ts
@@ -7,7 +7,7 @@ import {
 import { request, errors } from 'undici';
 import { ENV } from '../../env';
 import { RetryableJobError } from '../queue/errors';
-import { HttpError, JsonParseError } from '../util/errors';
+import { StacksNodeClarityError, HttpError, StacksNodeJsonParseError } from '../util/errors';
 
 interface ReadOnlyContractCallSuccessResponse {
   okay: true;
@@ -80,7 +80,7 @@ export class StacksNodeRpcClient {
       try {
         return JSON.parse(text) as ReadOnlyContractCallResponse;
       } catch (error) {
-        throw new JsonParseError(`JSON parse error ${url}: ${text}`);
+        throw new StacksNodeJsonParseError(`JSON parse error ${url}: ${text}`);
       }
     } catch (error) {
       if (error instanceof errors.UndiciError) {
@@ -107,7 +107,7 @@ export class StacksNodeRpcClient {
           `Runtime error while calling read-only function ${functionName}`
         );
       }
-      throw new Error(`Read-only error ${functionName}: ${result.cause}`);
+      throw new StacksNodeClarityError(`Read-only error ${functionName}: ${result.cause}`);
     }
     return decodeClarityValue(result.result);
   }
@@ -128,7 +128,7 @@ export class StacksNodeRpcClient {
     if (unwrappedClarityValue.type_id === ClarityTypeID.UInt) {
       return unwrappedClarityValue;
     }
-    throw new Error(
+    throw new StacksNodeClarityError(
       `Unexpected Clarity type '${unwrappedClarityValue.type_id}' while unwrapping uint`
     );
   }
@@ -143,7 +143,7 @@ export class StacksNodeRpcClient {
     } else if (unwrappedClarityValue.type_id === ClarityTypeID.OptionalNone) {
       return undefined;
     }
-    throw new Error(
+    throw new StacksNodeClarityError(
       `Unexpected Clarity type '${unwrappedClarityValue.type_id}' while unwrapping string`
     );
   }

--- a/src/token-processor/util/errors.ts
+++ b/src/token-processor/util/errors.ts
@@ -1,8 +1,11 @@
 import { errors } from 'undici';
 import { parseRetryAfterResponseHeader } from './helpers';
 
+/** Tags an error as a user error i.e. caused by a bad contract, incorrect SIP-016 metadata, etc. */
+export class UserError extends Error {}
+
 /** Thrown when fetching metadata exceeds the max allowed byte size */
-export class MetadataSizeExceededError extends Error {
+export class MetadataSizeExceededError extends UserError {
   constructor(message: string) {
     super();
     this.message = message;
@@ -11,7 +14,7 @@ export class MetadataSizeExceededError extends Error {
 }
 
 /** Thrown when fetching metadata exceeds the max allowed timeout */
-export class MetadataTimeoutError extends Error {
+export class MetadataTimeoutError extends UserError {
   constructor(message: string) {
     super();
     this.message = message;
@@ -20,7 +23,15 @@ export class MetadataTimeoutError extends Error {
 }
 
 /** Thrown when there is a parse error that prevented metadata processing */
-export class MetadataParseError extends Error {
+export class MetadataParseError extends UserError {
+  constructor(message: string) {
+    super();
+    this.message = message;
+    this.name = this.constructor.name;
+  }
+}
+
+export class StacksNodeClarityError extends UserError {
   constructor(message: string) {
     super();
     this.message = message;
@@ -51,7 +62,7 @@ export class TooManyRequestsHttpError extends HttpError {
   }
 }
 
-export class JsonParseError extends Error {
+export class StacksNodeJsonParseError extends Error {
   constructor(message: string) {
     super();
     this.message = message;

--- a/src/token-processor/util/types.ts
+++ b/src/token-processor/util/types.ts
@@ -19,7 +19,7 @@ const RawMetadata = Type.Object(
   },
   { additionalProperties: true }
 );
-export type RawMetadataType = Static<typeof RawMetadata>;
+export type RawMetadata = Static<typeof RawMetadata>;
 export const RawMetadataCType = TypeCompiler.Compile(RawMetadata);
 
 // Raw metadata localization types.
@@ -44,7 +44,7 @@ const RawMetadataProperties = Type.Record(Type.String(), Type.Any());
 export const RawMetadataPropertiesCType = TypeCompiler.Compile(RawMetadataProperties);
 
 export type RawMetadataLocale = {
-  metadata: RawMetadataType;
+  metadata: RawMetadata;
   locale?: string;
   default: boolean;
   uri: string;

--- a/tests/ft.test.ts
+++ b/tests/ft.test.ts
@@ -55,6 +55,28 @@ describe('FT routes', () => {
     expect(response.json()).toStrictEqual({ error: 'Token metadata fetch in progress' });
   });
 
+  test('invalid contract', async () => {
+    await enqueueToken();
+    await db.sql`UPDATE jobs SET status = 'invalid' WHERE id = 1`;
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/ft/SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS.hello-world',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json().error).toMatch(/Token contract/);
+  });
+
+  test('invalid token metadata', async () => {
+    await enqueueToken();
+    await db.sql`UPDATE jobs SET status = 'invalid' WHERE id = 2`;
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/ft/SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS.hello-world',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json().error).toMatch(/Token metadata/);
+  });
+
   test('locale not found', async () => {
     await enqueueToken();
     await db.updateProcessedTokenWithMetadata({

--- a/tests/metadata-helpers.test.ts
+++ b/tests/metadata-helpers.test.ts
@@ -44,9 +44,7 @@ describe('Metadata Helpers', () => {
       .reply(200, '[{"test-bad-json": true}]');
     setGlobalDispatcher(agent);
 
-    await expect(getMetadataFromUri('http://test.io/1.json')).rejects.toThrow(
-      /Invalid raw metadata JSON schema/
-    );
+    await expect(getMetadataFromUri('http://test.io/1.json')).rejects.toThrow(/JSON parse error/);
   });
 
   test('throws metadata http errors', async () => {

--- a/tests/nft.test.ts
+++ b/tests/nft.test.ts
@@ -20,7 +20,7 @@ describe('NFT routes', () => {
     await db.close();
   });
 
-  const enqueueToken = async () => {
+  const enqueueContract = async () => {
     const values: DbSmartContractInsert = {
       principal: 'SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS.hello-world',
       sip: DbSipNumber.sip009,
@@ -29,6 +29,10 @@ describe('NFT routes', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
+  };
+
+  const enqueueToken = async () => {
+    await enqueueContract();
     await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
       token_count: 1n,
@@ -36,13 +40,23 @@ describe('NFT routes', () => {
     });
   };
 
-  test('token not found', async () => {
+  test('contract not found', async () => {
     const response = await fastify.inject({
       method: 'GET',
       url: '/metadata/v1/nft/SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS.hello-world/1',
     });
     expect(response.statusCode).toBe(404);
-    expect(response.json()).toStrictEqual({ error: 'Token not found' });
+    expect(response.json().error).toMatch(/Contract not found/);
+  });
+
+  test('token not found', async () => {
+    await enqueueContract();
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/nft/SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS.hello-world/1',
+    });
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error).toMatch(/Token not found/);
   });
 
   test('token not processed', async () => {

--- a/tests/nft.test.ts
+++ b/tests/nft.test.ts
@@ -55,6 +55,28 @@ describe('NFT routes', () => {
     expect(response.json()).toStrictEqual({ error: 'Token metadata fetch in progress' });
   });
 
+  test('invalid contract', async () => {
+    await enqueueToken();
+    await db.sql`UPDATE jobs SET status = 'invalid' WHERE id = 1`;
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/nft/SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS.hello-world/1',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json().error).toMatch(/Token contract/);
+  });
+
+  test('invalid token metadata', async () => {
+    await enqueueToken();
+    await db.sql`UPDATE jobs SET status = 'invalid' WHERE id = 2`;
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/nft/SP2SYHR84SDJJDK8M09HFS4KBFXPPCX9H7RZ9YVTS.hello-world/1',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json().error).toMatch(/Token metadata/);
+  });
+
   test('locale not found', async () => {
     await enqueueToken();
     await db.updateProcessedTokenWithMetadata({

--- a/tests/sft.test.ts
+++ b/tests/sft.test.ts
@@ -59,6 +59,28 @@ describe('SFT routes', () => {
     expect(response.json()).toStrictEqual({ error: 'Token metadata fetch in progress' });
   });
 
+  test('invalid contract', async () => {
+    await enqueueToken();
+    await db.sql`UPDATE jobs SET status = 'invalid' WHERE id = 1`;
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json().error).toMatch(/Token contract/);
+  });
+
+  test('invalid token metadata', async () => {
+    await enqueueToken();
+    await db.sql`UPDATE jobs SET status = 'invalid' WHERE id = 2`;
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json().error).toMatch(/Token metadata/);
+  });
+
   test('locale not found', async () => {
     await enqueueToken();
     await db.updateProcessedTokenWithMetadata({

--- a/tests/sft.test.ts
+++ b/tests/sft.test.ts
@@ -20,7 +20,7 @@ describe('SFT routes', () => {
     await db.close();
   });
 
-  const enqueueToken = async () => {
+  const enqueueContract = async () => {
     const address = 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9';
     const contractId = 'key-alex-autoalex-v1';
     const values: DbSmartContractInsert = {
@@ -31,6 +31,10 @@ describe('SFT routes', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
+  };
+
+  const enqueueToken = async () => {
+    await enqueueContract();
     await db.insertAndEnqueueTokenArray([
       {
         smart_contract_id: 1,
@@ -40,13 +44,23 @@ describe('SFT routes', () => {
     ]);
   };
 
-  test('token not found', async () => {
+  test('contract not found', async () => {
     const response = await fastify.inject({
       method: 'GET',
-      url: '/metadata/v1/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+      url: '/metadata/v1/nft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
     });
     expect(response.statusCode).toBe(404);
-    expect(response.json()).toStrictEqual({ error: 'Token not found' });
+    expect(response.json().error).toMatch(/Contract not found/);
+  });
+
+  test('token not found', async () => {
+    await enqueueContract();
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/metadata/v1/nft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+    });
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error).toMatch(/Token not found/);
   });
 
   test('token not processed', async () => {

--- a/tests/stacks-node-rpc-client.test.ts
+++ b/tests/stacks-node-rpc-client.test.ts
@@ -10,7 +10,7 @@ import { MockAgent, setGlobalDispatcher } from 'undici';
 import { ENV } from '../src/env';
 import { RetryableJobError } from '../src/token-processor/queue/errors';
 import { StacksNodeRpcClient } from '../src/token-processor/stacks-node/stacks-node-rpc-client';
-import { HttpError, JsonParseError } from '../src/token-processor/util/errors';
+import { HttpError, StacksNodeJsonParseError } from '../src/token-processor/util/errors';
 
 describe('StacksNodeRpcClient', () => {
   const nodeUrl = `http://${ENV.STACKS_NODE_RPC_HOST}:${ENV.STACKS_NODE_RPC_PORT}`;
@@ -109,7 +109,7 @@ describe('StacksNodeRpcClient', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(RetryableJobError);
       const err = error as RetryableJobError;
-      expect(err.cause).toBeInstanceOf(JsonParseError);
+      expect(err.cause).toBeInstanceOf(StacksNodeJsonParseError);
     }
   });
 


### PR DESCRIPTION
* Add `invalid` job status
* Mark invalid when there is a user error (wrong metadata format, not SIP-016, unreachable, bad clarity types, etc.)
* Respond with an informative error if invalid contracts/tokens are requested

Fixes #128 
Fixes #118
Fixes #138 