### PR TITLE
feat: add endpoint to list all FTs

### DIFF
--- a/migrations/1686538772911_ft-list-indices.ts
+++ b/migrations/1686538772911_ft-list-indices.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createIndex('tokens', ['name']);
+  pgm.createIndex('tokens', ['symbol']);
+}

--- a/src/api/routes/ft.ts
+++ b/src/api/routes/ft.ts
@@ -1,13 +1,70 @@
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox';
-import { FastifyPluginCallback } from 'fastify';
+import { FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
 import { Server } from 'http';
-import { FtMetadataResponse, FtPrincipalParam, TokenQuerystringParams } from '../schemas';
+import {
+  FtMetadataResponse,
+  FtPrincipalParam,
+  LimitParam,
+  OffsetParam,
+  PaginatedResponse,
+  TokenQuerystringParams,
+} from '../schemas';
 import { handleTokenCache } from '../util/cache';
 import { generateTokenErrorResponse, TokenErrorResponseSchema } from '../util/errors';
 import { parseMetadataLocaleBundle } from '../util/helpers';
 
-export const FtRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (
+const IndexRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (
+  fastify,
+  options,
+  done
+) => {
+  fastify.get(
+    '/ft',
+    {
+      schema: {
+        operationId: 'getFungibleTokens',
+        summary: 'Fungible Tokens',
+        description: 'Retrieves a list of Fungible Tokens',
+        tags: ['Tokens'],
+        querystring: Type.Object({
+          // Pagination
+          offset: Type.Optional(OffsetParam),
+          limit: Type.Optional(LimitParam),
+        }),
+        response: {
+          200: PaginatedResponse(FtMetadataResponse, 'Paginated Ft Metadata Response'),
+        },
+      },
+    },
+    async (request, reply) => {
+      const limit = request.query.limit ?? 20;
+      const offset = request.query.offset ?? 0;
+      const tokens = await fastify.db.getFungibleTokens({
+        page: { limit, offset },
+      });
+      await reply.send({
+        limit,
+        offset,
+        total: tokens.total,
+        results: tokens.results.map(t => ({
+          name: t.name,
+          symbol: t.symbol,
+          decimals: t.decimals,
+          total_supply: t.total_supply?.toString(),
+          token_uri: t.uri,
+          description: t.description,
+          tx_id: t.tx_id,
+          sender_address: t.principal?.split('.')[0],
+          image_uri: t.cached_image,
+          image_canonical_uri: t.image,
+        })),
+      });
+    }
+  );
+};
+
+const ShowRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (
   fastify,
   options,
   done
@@ -57,4 +114,13 @@ export const FtRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeB
     }
   );
   done();
+};
+
+export const FtRoutes: FastifyPluginAsync<
+  Record<never, never>,
+  Server,
+  TypeBoxTypeProvider
+> = async fastify => {
+  await fastify.register(IndexRoutes);
+  await fastify.register(ShowRoutes);
 };

--- a/src/api/routes/ft.ts
+++ b/src/api/routes/ft.ts
@@ -8,6 +8,7 @@ import {
   LimitParam,
   OffsetParam,
   PaginatedResponse,
+  StacksAddressParam,
   TokenQuerystringParams,
 } from '../schemas';
 import { handleTokenCache } from '../util/cache';
@@ -28,6 +29,9 @@ const IndexRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTy
         description: 'Retrieves a list of Fungible Tokens',
         tags: ['Tokens'],
         querystring: Type.Object({
+          name: Type.Optional(Type.String()),
+          symbol: Type.Optional(Type.String()),
+          address: Type.Optional(StacksAddressParam),
           // Pagination
           offset: Type.Optional(OffsetParam),
           limit: Type.Optional(LimitParam),
@@ -42,6 +46,11 @@ const IndexRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTy
       const offset = request.query.offset ?? 0;
       const tokens = await fastify.db.getFungibleTokens({
         page: { limit, offset },
+        filters: {
+          name: request.query.name,
+          symbol: request.query.symbol,
+          address: request.query.address,
+        },
       });
       await reply.send({
         limit,
@@ -62,6 +71,7 @@ const IndexRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTy
       });
     }
   );
+  done();
 };
 
 const ShowRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (

--- a/src/api/routes/ft.ts
+++ b/src/api/routes/ft.ts
@@ -4,9 +4,13 @@ import { FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
 import { Server } from 'http';
 import {
   FtMetadataResponse,
+  FtOrderBy,
+  FtOrderByParam,
   FtPrincipalParam,
   LimitParam,
   OffsetParam,
+  Order,
+  OrderParam,
   PaginatedResponse,
   StacksAddressParam,
   TokenQuerystringParams,
@@ -35,6 +39,9 @@ const IndexRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTy
           // Pagination
           offset: Type.Optional(OffsetParam),
           limit: Type.Optional(LimitParam),
+          // Ordering
+          order_by: Type.Optional(FtOrderByParam),
+          order: Type.Optional(OrderParam),
         }),
         response: {
           200: PaginatedResponse(FtMetadataResponse, 'Paginated Ft Metadata Response'),
@@ -50,6 +57,10 @@ const IndexRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTy
           name: request.query.name,
           symbol: request.query.symbol,
           address: request.query.address,
+        },
+        order: {
+          order_by: request.query.order_by ?? FtOrderBy.name,
+          order: request.query.order ?? Order.asc,
         },
       });
       await reply.send({

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -43,7 +43,7 @@ export const OpenApiSchemaOptions: SwaggerOptions = {
 // ==========================
 
 export const SmartContractRegEx =
-  /[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}/;
+  /^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}$/;
 
 export const TokenQuerystringParams = Type.Object({
   locale: Type.Optional(
@@ -71,6 +71,12 @@ export const SftPrincipalParam = Type.RegEx(SmartContractRegEx, {
   title: 'Semi-Fungible Token Contract Principal',
   description: 'SIP-013 compliant smart contract principal',
   examples: ['SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1'],
+});
+
+export const StacksAddressParam = Type.RegEx(/^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}/, {
+  title: 'Stacks Address',
+  description: 'Stacks Address',
+  examples: ['SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9'],
 });
 
 export const TokenIdParam = Type.Integer({

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -98,6 +98,24 @@ export const LimitParam = Type.Integer({
   description: 'Results per page',
 });
 
+export enum FtOrderBy {
+  name = 'name',
+  symbol = 'symbol',
+}
+export const FtOrderByParam = Type.Enum(FtOrderBy, {
+  title: 'Order By',
+  description: 'Parameter to order results by',
+});
+
+export enum Order {
+  asc = 'asc',
+  desc = 'desc',
+}
+export const OrderParam = Type.Enum(Order, {
+  title: 'Order',
+  description: 'Results order',
+});
+
 // ==========================
 // Responses
 // ==========================

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,5 +1,5 @@
 import { SwaggerOptions } from '@fastify/swagger';
-import { Static, Type } from '@sinclair/typebox';
+import { Static, TSchema, Type } from '@sinclair/typebox';
 import { SERVER_VERSION } from '../server-version';
 
 export const OpenApiSchemaOptions: SwaggerOptions = {
@@ -77,6 +77,19 @@ export const TokenIdParam = Type.Integer({
   title: 'Token ID',
   description: 'Token ID to retrieve',
   examples: ['35'],
+});
+
+export const OffsetParam = Type.Integer({
+  minimum: 0,
+  title: 'Offset',
+  description: 'Result offset',
+});
+
+export const LimitParam = Type.Integer({
+  minimum: 1,
+  maximum: 60,
+  title: 'Limit',
+  description: 'Results per page',
 });
 
 // ==========================
@@ -206,6 +219,17 @@ export const ErrorResponse = Type.Union(
   ],
   { title: 'Error Response' }
 );
+
+export const PaginatedResponse = <T extends TSchema>(type: T, title: string) =>
+  Type.Object(
+    {
+      limit: Type.Integer({ examples: [20] }),
+      offset: Type.Integer({ examples: [0] }),
+      total: Type.Integer({ examples: [1] }),
+      results: Type.Array(type),
+    },
+    { title }
+  );
 
 export const FtMetadataResponse = Type.Object(
   {

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -491,13 +491,15 @@ export class PgStore extends BasePgStore {
         FROM tokens AS t
         INNER JOIN metadata AS m ON t.id = m.token_id
         INNER JOIN smart_contracts AS s ON t.smart_contract_id = s.id
-        WHERE
-          t.type = 'ft'
+        WHERE t.type = 'ft'
+          ${args.filters?.name ? sql`AND t.name LIKE '%${args.filters.name}%'` : sql``}
+          ${args.filters?.symbol ? sql`AND t.symbol = ${args.filters.symbol}` : sql``}
+          ${args.filters?.address ? sql`AND s.principal LIKE '${args.filters.address}%'` : sql``}
         LIMIT ${args.page.limit}
         OFFSET ${args.page.offset}
       `;
       return {
-        total: 0,
+        total: 0, // TODO: Total
         results: results ?? [],
       };
     });

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -192,6 +192,35 @@ export type DbTokenMetadataLocaleBundle = {
   metadataLocale?: DbMetadataLocaleBundle;
 };
 
+export type DbIndexPaging = {
+  limit: number;
+  offset: number;
+};
+
+export type DbFungibleTokenFilters = {
+  name?: string;
+  symbol?: string;
+  address?: string;
+};
+
+export type DbPaginatedResult<T> = {
+  total: number;
+  results: T[];
+};
+
+export type DbFungibleTokenMetadataItem = {
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+  total_supply?: bigint;
+  uri?: string;
+  description?: string;
+  tx_id: string;
+  principal: string;
+  image?: string;
+  cached_image?: string;
+};
+
 export const SMART_CONTRACTS_COLUMNS = [
   'id',
   'principal',

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -1,3 +1,4 @@
+import { FtOrderBy, Order } from '../api/schemas';
 import { PgJsonb, PgNumeric } from './postgres-tools/types';
 
 export enum DbSipNumber {
@@ -201,6 +202,11 @@ export type DbFungibleTokenFilters = {
   name?: string;
   symbol?: string;
   address?: string;
+};
+
+export type DbFungibleTokenOrder = {
+  order_by?: FtOrderBy;
+  order?: Order;
 };
 
 export type DbPaginatedResult<T> = {

--- a/tests/ft.test.ts
+++ b/tests/ft.test.ts
@@ -1,7 +1,12 @@
 import { ENV } from '../src/env';
 import { cycleMigrations } from '../src/pg/migrations';
 import { PgStore } from '../src/pg/pg-store';
-import { DbSipNumber, DbSmartContractInsert, DbTokenType } from '../src/pg/types';
+import {
+  DbFungibleTokenMetadataItem,
+  DbSipNumber,
+  DbSmartContractInsert,
+  DbTokenType,
+} from '../src/pg/types';
 import { startTestApiServer, TestFastifyServer } from './helpers';
 
 describe('FT routes', () => {
@@ -255,5 +260,145 @@ describe('FT routes', () => {
     });
     expect(response.statusCode).toEqual(noVersionResponse.statusCode);
     expect(response.json()).toStrictEqual(noVersionResponse.json());
+  });
+
+  describe('index', () => {
+    const insertFt = async (item: DbFungibleTokenMetadataItem) => {
+      const values: DbSmartContractInsert = {
+        principal: item.principal,
+        sip: DbSipNumber.sip010,
+        abi: '"some"',
+        tx_id: item.tx_id,
+        block_height: 1,
+      };
+      const job = await db.insertAndEnqueueSmartContract({ values });
+      const [tokenJob] = await db.insertAndEnqueueSequentialTokens({
+        smart_contract_id: job.smart_contract_id ?? 0,
+        token_count: 1n,
+        type: DbTokenType.ft,
+      });
+      await db.updateProcessedTokenWithMetadata({
+        id: tokenJob.token_id ?? 0,
+        values: {
+          token: {
+            name: item.name,
+            symbol: item.symbol,
+            decimals: item.decimals,
+            total_supply: item.total_supply?.toString(),
+            uri: item.uri ?? null,
+          },
+          metadataLocales: [
+            {
+              metadata: {
+                sip: 16,
+                token_id: tokenJob.token_id ?? 0,
+                name: item.name ?? '',
+                l10n_locale: 'en',
+                l10n_uri: null,
+                l10n_default: true,
+                description: item.description ?? '',
+                image: item.image ?? '',
+                cached_image: item.cached_image ?? '',
+              },
+            },
+          ],
+        },
+      });
+    };
+
+    test('shows a list of tokens', async () => {
+      await insertFt({
+        name: 'Meme token',
+        symbol: 'MEME',
+        decimals: 5,
+        description: 'Meme',
+        tx_id: '0xbdc41843d5e0cd4a70611f6badeb5c87b07b12309e77c4fbaf2334c7b4cee89b',
+        principal: 'SP22PCWZ9EJMHV4PHVS0C8H3B3E4Q079ZHY6CXDS1.meme-token',
+        total_supply: 200000n,
+        image: 'http://img.com/meme.jpg',
+        cached_image: 'http://img.com/meme.jpg',
+        uri: 'https://ipfs.io/abcd.json',
+      });
+      await insertFt({
+        name: 'miamicoin',
+        symbol: 'MIA',
+        decimals: 6,
+        total_supply: 5586789829000000n,
+        uri: 'https://cdn.citycoins.co/metadata/miamicoin.json',
+        description: 'A CityCoin for Miami, ticker is MIA, Stack it to earn Stacks (STX)',
+        image: 'https://cdn.citycoins.co/logos/miamicoin.png',
+        cached_image: 'https://cdn.citycoins.co/logos/miamicoin.png',
+        tx_id: '0xa80a44790929467693ccb33a212cf50878a6ad572c4c5b8e7d9a5de794fbefa2',
+        principal: 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2',
+      });
+      await insertFt({
+        name: 'STACKSWAP',
+        symbol: 'STSW',
+        decimals: 6,
+        total_supply: 1000000000000000n,
+        uri: 'https://app.stackswap.org/token/stsw.json',
+        description: 'StackSwap Project',
+        image: 'https://app.stackswap.org/icon/stsw.svg',
+        cached_image: 'https://app.stackswap.org/icon/stsw.svg',
+        tx_id: '0x3edffbd025ca2c29cfde8c583c0e0babacd4aa21075d10307d37c64ae78d579e',
+        principal: 'SP1Z92MPDQEWZXW36VX71Q25HKF5K2EPCJ304F275.stsw-token-v4a',
+      });
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft',
+      });
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.total).toBe(3);
+      expect(json.results[0]).toStrictEqual({
+        decimals: 5,
+        description: 'Meme',
+        image_canonical_uri: 'http://img.com/meme.jpg',
+        image_uri: 'http://img.com/meme.jpg',
+        name: 'Meme token',
+        sender_address: 'SP22PCWZ9EJMHV4PHVS0C8H3B3E4Q079ZHY6CXDS1',
+        symbol: 'MEME',
+        token_uri: 'https://ipfs.io/abcd.json',
+        total_supply: '200000',
+        tx_id: '0xbdc41843d5e0cd4a70611f6badeb5c87b07b12309e77c4fbaf2334c7b4cee89b',
+      });
+      expect(json.results[1]).toStrictEqual({
+        decimals: 6,
+        description: 'A CityCoin for Miami, ticker is MIA, Stack it to earn Stacks (STX)',
+        image_canonical_uri: 'https://cdn.citycoins.co/logos/miamicoin.png',
+        image_uri: 'https://cdn.citycoins.co/logos/miamicoin.png',
+        name: 'miamicoin',
+        sender_address: 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R',
+        symbol: 'MIA',
+        token_uri: 'https://cdn.citycoins.co/metadata/miamicoin.json',
+        total_supply: '5586789829000000',
+        tx_id: '0xa80a44790929467693ccb33a212cf50878a6ad572c4c5b8e7d9a5de794fbefa2',
+      });
+      expect(json.results[2]).toStrictEqual({
+        decimals: 6,
+        description: 'StackSwap Project',
+        image_canonical_uri: 'https://app.stackswap.org/icon/stsw.svg',
+        image_uri: 'https://app.stackswap.org/icon/stsw.svg',
+        name: 'STACKSWAP',
+        sender_address: 'SP1Z92MPDQEWZXW36VX71Q25HKF5K2EPCJ304F275',
+        symbol: 'STSW',
+        token_uri: 'https://app.stackswap.org/token/stsw.json',
+        total_supply: '1000000000000000',
+        tx_id: '0x3edffbd025ca2c29cfde8c583c0e0babacd4aa21075d10307d37c64ae78d579e',
+      });
+    });
+
+    test('filters by name', async () => {
+      //
+    });
+
+    test('filters by symbol', async () => {
+      //
+    });
+
+    test('filters by address', async () => {
+      //
+    });
   });
 });

--- a/tests/ft.test.ts
+++ b/tests/ft.test.ts
@@ -306,7 +306,7 @@ describe('FT routes', () => {
       });
     };
 
-    test('shows a list of tokens', async () => {
+    const insertFtList = async () => {
       await insertFt({
         name: 'Meme token',
         symbol: 'MEME',
@@ -343,7 +343,10 @@ describe('FT routes', () => {
         tx_id: '0x3edffbd025ca2c29cfde8c583c0e0babacd4aa21075d10307d37c64ae78d579e',
         principal: 'SP1Z92MPDQEWZXW36VX71Q25HKF5K2EPCJ304F275.stsw-token-v4a',
       });
+    };
 
+    test('shows a list of tokens', async () => {
+      await insertFtList();
       const response = await fastify.inject({
         method: 'GET',
         url: '/metadata/ft',
@@ -390,15 +393,39 @@ describe('FT routes', () => {
     });
 
     test('filters by name', async () => {
-      //
+      await insertFtList();
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?name=miami', // Partial match
+      });
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.total).toBe(1);
+      expect(json.results[0].symbol).toBe('MIA');
     });
 
     test('filters by symbol', async () => {
-      //
+      await insertFtList();
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?symbol=MIA',
+      });
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.total).toBe(1);
+      expect(json.results[0].symbol).toBe('MIA');
     });
 
     test('filters by address', async () => {
-      //
+      await insertFtList();
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?address=SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R',
+      });
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.total).toBe(1);
+      expect(json.results[0].symbol).toBe('MIA');
     });
   });
 });

--- a/tests/ft.test.ts
+++ b/tests/ft.test.ts
@@ -427,5 +427,55 @@ describe('FT routes', () => {
       expect(json.total).toBe(1);
       expect(json.results[0].symbol).toBe('MIA');
     });
+
+    test('sorts by name', async () => {
+      await insertFtList();
+      const response1 = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?order_by=name&order=asc',
+      });
+      expect(response1.statusCode).toBe(200);
+      const json1 = response1.json();
+      expect(json1.total).toBe(3);
+      expect(json1.results[0].symbol).toBe('MEME');
+      expect(json1.results[1].symbol).toBe('MIA');
+      expect(json1.results[2].symbol).toBe('STSW');
+
+      const response2 = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?order_by=name&order=desc',
+      });
+      expect(response2.statusCode).toBe(200);
+      const json2 = response2.json();
+      expect(json2.total).toBe(3);
+      expect(json2.results[0].symbol).toBe('STSW');
+      expect(json2.results[1].symbol).toBe('MIA');
+      expect(json2.results[2].symbol).toBe('MEME');
+    });
+
+    test('sorts by symbol', async () => {
+      await insertFtList();
+      const response1 = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?order_by=symbol&order=asc',
+      });
+      expect(response1.statusCode).toBe(200);
+      const json1 = response1.json();
+      expect(json1.total).toBe(3);
+      expect(json1.results[0].symbol).toBe('MEME');
+      expect(json1.results[1].symbol).toBe('MIA');
+      expect(json1.results[2].symbol).toBe('STSW');
+
+      const response2 = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?order_by=symbol&order=desc',
+      });
+      expect(response2.statusCode).toBe(200);
+      const json2 = response2.json();
+      expect(json2.total).toBe(3);
+      expect(json2.results[0].symbol).toBe('STSW');
+      expect(json2.results[1].symbol).toBe('MIA');
+      expect(json2.results[2].symbol).toBe('MEME');
+    });
   });
 });


### PR DESCRIPTION
Creates a new endpoint `/metadata/ft` which:

* Lists all fungible tokens with valid metadata
    * Results include basic metadata, not detailed metadata
* Filters by `name` (LIKE match) or `symbol`
* Orders results by `name` or `symbol`

Fixes #161 