### PR TITLE
feat: make FT search on name and symbol case insensitive

### DIFF
--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -509,8 +509,12 @@ export class PgStore extends BasePgStore {
         INNER JOIN metadata AS m ON t.id = m.token_id
         INNER JOIN smart_contracts AS s ON t.smart_contract_id = s.id
         WHERE t.type = 'ft'
-          ${args.filters?.name ? sql`AND t.name LIKE ${'%' + args.filters.name + '%'}` : sql``}
-          ${args.filters?.symbol ? sql`AND t.symbol = ${args.filters.symbol}` : sql``}
+          ${
+            args.filters?.name
+              ? sql`AND LOWER(t.name) LIKE LOWER(${'%' + args.filters.name + '%'})`
+              : sql``
+          }
+          ${args.filters?.symbol ? sql`AND LOWER(t.symbol) = LOWER(${args.filters.symbol})` : sql``}
           ${args.filters?.address ? sql`AND s.principal LIKE ${args.filters.address + '%'}` : sql``}
         ORDER BY ${orderBy} ${order}
         LIMIT ${args.page.limit}

--- a/tests/ft.test.ts
+++ b/tests/ft.test.ts
@@ -413,6 +413,15 @@ describe('FT routes', () => {
       expect(response2.statusCode).toBe(200);
       const json2 = response2.json();
       expect(json2.total).toBe(0);
+
+      const response3 = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?name=Miami', // Case insensitive
+      });
+      expect(response3.statusCode).toBe(200);
+      const json3 = response3.json();
+      expect(json3.total).toBe(1);
+      expect(json3.results[0].symbol).toBe('MIA');
     });
 
     test('filters by symbol', async () => {
@@ -433,6 +442,15 @@ describe('FT routes', () => {
       expect(response2.statusCode).toBe(200);
       const json2 = response2.json();
       expect(json2.total).toBe(0);
+
+      const response3 = await fastify.inject({
+        method: 'GET',
+        url: '/metadata/ft?symbol=mia', // Case insensitive
+      });
+      expect(response3.statusCode).toBe(200);
+      const json3 = response3.json();
+      expect(json3.total).toBe(1);
+      expect(json3.results[0].symbol).toBe('MIA');
     });
 
     test('filters by address', async () => {


### PR DESCRIPTION
### Description

Makes the FT search on `name` and `symbol` case insensitive.

#### Breaking change?

No

### Example

`/metadata/ft?symbol=mia`

---

### Checklist

- [x] All tests pass
- [x] Tests added in this PR (if applicable)

