### PR TITLE
fix: handle missing image uris

### DIFF
--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -123,6 +123,8 @@ async function parseMetadataForInsertion(
       metadata.image ??
       metadata.imageUrl ??
       metadata.image_url ??
+      metadata.image_uri ??
+      metadata.image_canonical_uri ??
       defaultInsert?.metadata.image ??
       null;
     let cachedImage: string | null = null;
@@ -137,7 +139,7 @@ async function parseMetadataForInsertion(
       name: name.toString(),
       description:
         metadata.description?.toString() ?? defaultInsert?.metadata.description?.toString() ?? null,
-      image: image?.toString(),
+      image: image ? image.toString() : null,
       cached_image: cachedImage,
       l10n_default: raw.default,
       l10n_locale: raw.locale ?? null,

--- a/src/token-processor/util/types.ts
+++ b/src/token-processor/util/types.ts
@@ -16,6 +16,8 @@ const RawMetadata = Type.Object(
     // Properties below are not SIP-016 compliant.
     imageUrl: Type.Optional(Type.Any()),
     image_url: Type.Optional(Type.Any()),
+    image_uri: Type.Optional(Type.Any()),
+    image_canonical_uri: Type.Optional(Type.Any()),
   },
   { additionalProperties: true }
 );


### PR DESCRIPTION
Also accept other non-compliant image fields `image_uri` and `image_canonical_uri`