### PR TITLE
fix: demote server connection errors and contract clarity errors to be non-retryable

### DIFF
--- a/src/token-processor/images/image-cache.ts
+++ b/src/token-processor/images/image-cache.ts
@@ -158,7 +158,7 @@ export async function processImageCache(
         throw new ImageSizeExceededError(`ImageCache image too large: ${imgUrl}`);
       }
       if ((typeError.cause as any).toString().includes('ECONNRESET')) {
-        throw new RetryableJobError(`ImageCache server connection interrupted`, typeError);
+        throw new ImageHttpError(`ImageCache server connection interrupted`, typeError);
       }
     }
     throw error;

--- a/src/token-processor/queue/job/process-token-job.ts
+++ b/src/token-processor/queue/job/process-token-job.ts
@@ -9,7 +9,7 @@ import {
   DbTokenType,
 } from '../../../pg/types';
 import { StacksNodeRpcClient } from '../../stacks-node/stacks-node-rpc-client';
-import { StacksNodeClarityError, TooManyRequestsHttpError } from '../../util/errors';
+import { SmartContractClarityError, TooManyRequestsHttpError } from '../../util/errors';
 import {
   fetchAllMetadataLocalesFromBaseUri,
   getFetchableDecentralizedStorageUrl,
@@ -108,7 +108,7 @@ export class ProcessTokenJob extends Job {
     } catch (error) {
       // We'll treat Clarity errors here as if the supply was `undefined` to accommodate ALEX's
       // wrapped tokens which return an error in `get-total-supply`.
-      if (!(error instanceof StacksNodeClarityError)) {
+      if (!(error instanceof SmartContractClarityError)) {
         throw error;
       }
     }

--- a/src/token-processor/util/errors.ts
+++ b/src/token-processor/util/errors.ts
@@ -44,7 +44,7 @@ export class MetadataParseError extends UserError {
 
 export class ImageParseError extends MetadataParseError {}
 
-export class StacksNodeClarityError extends UserError {
+export class SmartContractClarityError extends UserError {
   constructor(message: string) {
     super();
     this.message = message;
@@ -111,7 +111,7 @@ export function getUserErrorInvalidReason(error: UserError): DbJobInvalidReason 
       return DbJobInvalidReason.metadataHttpError;
     case error instanceof ImageHttpError:
       return DbJobInvalidReason.imageHttpError;
-    case error instanceof StacksNodeClarityError:
+    case error instanceof SmartContractClarityError:
       return DbJobInvalidReason.tokenContractClarityError;
     default:
       return DbJobInvalidReason.unknown;

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -97,14 +97,6 @@ export async function fetchAllMetadataLocalesFromBaseUri(
       break;
     } catch (error) {
       fetchImmediateRetryCount++;
-      if (
-        error instanceof MetadataTimeoutError &&
-        isUriFromDecentralizedStorage(error.url.toString())
-      ) {
-        // Gateways like IPFS and Arweave commonly time out when a resource can't be found quickly.
-        // Try again later if this is the case.
-        throw new RetryableJobError(`Gateway timeout for ${error.url}`, error);
-      }
       if (error instanceof TooManyRequestsHttpError) {
         // 429 status codes are common when fetching metadata for thousands of tokens in the same
         // server.
@@ -268,7 +260,7 @@ export async function fetchMetadata(httpUrl: URL): Promise<string | undefined> {
       error instanceof TypeError &&
       ((error as UndiciCauseTypeError).cause as any).toString().includes('ECONNRESET')
     ) {
-      throw new RetryableJobError(`Server connection interrupted`, error);
+      throw new MetadataHttpError(`Server connection interrupted`, error);
     }
     throw new MetadataHttpError(`${url}: ${error}`, error);
   }

--- a/tests/token-queue/metadata-helpers.test.ts
+++ b/tests/token-queue/metadata-helpers.test.ts
@@ -228,6 +228,6 @@ describe('Metadata Helpers', () => {
       .replyWithError(Object.assign(new TypeError(), { cause: new Error('read ECONNRESET') }));
     setGlobalDispatcher(agent);
 
-    await expect(fetchMetadata(url)).rejects.toThrow(RetryableJobError);
+    await expect(fetchMetadata(url)).rejects.toThrow(MetadataHttpError);
   });
 });

--- a/tests/token-queue/stacks-node-rpc-client.test.ts
+++ b/tests/token-queue/stacks-node-rpc-client.test.ts
@@ -13,6 +13,7 @@ import { StacksNodeRpcClient } from '../../src/token-processor/stacks-node/stack
 import {
   StacksNodeJsonParseError,
   StacksNodeHttpError,
+  SmartContractClarityError,
 } from '../../src/token-processor/util/errors';
 
 describe('StacksNodeRpcClient', () => {
@@ -69,7 +70,7 @@ describe('StacksNodeRpcClient', () => {
     setGlobalDispatcher(agent);
 
     await expect(client.readStringFromContract('get-token-uri', [])).rejects.toThrow(
-      RetryableJobError
+      SmartContractClarityError
     );
   });
 
@@ -110,9 +111,7 @@ describe('StacksNodeRpcClient', () => {
     try {
       await client.readStringFromContract('get-token-uri', []);
     } catch (error) {
-      expect(error).toBeInstanceOf(RetryableJobError);
-      const err = error as RetryableJobError;
-      expect(err.cause).toBeInstanceOf(StacksNodeHttpError);
+      expect(error).toBeInstanceOf(StacksNodeHttpError);
     }
   });
 
@@ -131,9 +130,7 @@ describe('StacksNodeRpcClient', () => {
     try {
       await client.readStringFromContract('get-token-uri', []);
     } catch (error) {
-      expect(error).toBeInstanceOf(RetryableJobError);
-      const err = error as RetryableJobError;
-      expect(err.cause).toBeInstanceOf(StacksNodeJsonParseError);
+      expect(error).toBeInstanceOf(StacksNodeJsonParseError);
     }
   });
 


### PR DESCRIPTION
Some of the errors we were considering as retryable were not really retryable. For example, if a metadata server produced an `ECONNRESET` error, most of the time it was an error that happened consistently even when retrying after a while. Since we're running in strict mode, this caused an inifite retry of these jobs which makes no sense.

Because of this, this PR only leaves temporary Stacks node errors and 429 rate limit errors to be infinitely retryable because they are (almost) guaranteed to be resolved after a number of retries.