### PR TITLE
fix: retry when a contract is not yet found

### DIFF
--- a/src/token-processor/stacks-node/stacks-node-rpc-client.ts
+++ b/src/token-processor/stacks-node/stacks-node-rpc-client.ts
@@ -138,7 +138,7 @@ export class StacksNodeRpcClient {
           `Runtime error while calling read-only function ${functionName}`
         );
       } else if (result.cause.includes('NoSuchContract')) {
-        throw new SmartContractClarityError(
+        throw new RetryableJobError(
           `Contract not available yet when calling read-only function ${functionName}`
         );
       }

--- a/tests/token-queue/stacks-node-rpc-client.test.ts
+++ b/tests/token-queue/stacks-node-rpc-client.test.ts
@@ -13,7 +13,6 @@ import { StacksNodeRpcClient } from '../../src/token-processor/stacks-node/stack
 import {
   StacksNodeJsonParseError,
   StacksNodeHttpError,
-  SmartContractClarityError,
 } from '../../src/token-processor/util/errors';
 
 describe('StacksNodeRpcClient', () => {
@@ -70,7 +69,7 @@ describe('StacksNodeRpcClient', () => {
     setGlobalDispatcher(agent);
 
     await expect(client.readStringFromContract('get-token-uri', [])).rejects.toThrow(
-      SmartContractClarityError
+      RetryableJobError
     );
   });
 


### PR DESCRIPTION
When detecting a new contract or token via chainhook, we do a read-only call to that contract in the Stacks node immediately to get the token's data. However, if that contract is not yet ready for read on the node (`NoSuchContract` error), we need to try again later.