### PR TITLE
feat: add configurable delay for retrying jobs

### DIFF
--- a/migrations/1725039927416_job-retry-after.ts
+++ b/migrations/1725039927416_job-retry-after.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumn('jobs', {
+    retry_after: {
+      type: 'timestamptz',
+    },
+  });
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -84,6 +84,8 @@ const schema = Type.Object({
   JOB_QUEUE_SIZE_LIMIT: Type.Number({ default: 200 }),
   /** Maximum time a job will run before marking it as failed. */
   JOB_QUEUE_TIMEOUT_MS: Type.Number({ default: 60_000 }),
+  /** Minimum time we will wait to retry a job after it's been executed. */
+  JOB_QUEUE_RETRY_AFTER_MS: Type.Number({ default: 5_000 }),
 
   /**
    * The max number of immediate attempts that will be made to retrieve metadata from external URIs

--- a/src/env.ts
+++ b/src/env.ts
@@ -120,7 +120,7 @@ const schema = Type.Object({
    * next request that is sent to it (seconds). This value will be overridden by the `Retry-After`
    * header returned by the domain, if any.
    */
-  METADATA_RATE_LIMITED_HOST_RETRY_AFTER: Type.Number({ default: 3600 }), // 1 hour
+  METADATA_RATE_LIMITED_HOST_RETRY_AFTER: Type.Number({ default: 60 }), // 1 minute
   /**
    * Maximum number of HTTP redirections to follow when fetching metadata. Defaults to 5.
    */

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -106,6 +106,7 @@ export type DbJob = {
   retry_count: number;
   created_at: string;
   updated_at?: string;
+  retry_after?: string;
 };
 
 export type DbUpdateNotification = {
@@ -285,6 +286,7 @@ export const JOBS_COLUMNS = [
   'retry_count',
   'created_at',
   'updated_at',
+  'retry_after',
 ];
 
 export const METADATA_COLUMNS = [

--- a/src/token-processor/queue/job/job.ts
+++ b/src/token-processor/queue/job/job.ts
@@ -52,7 +52,10 @@ export abstract class Job {
       }
     } catch (error) {
       if (error instanceof RetryableJobError) {
-        const retries = await this.db.increaseJobRetryCount({ id: this.job.id });
+        const retries = await this.db.increaseJobRetryCount({
+          id: this.job.id,
+          retry_after: ENV.JOB_QUEUE_RETRY_AFTER_MS,
+        });
         if (
           getJobQueueProcessingMode() === JobQueueProcessingMode.strict ||
           retries <= ENV.JOB_QUEUE_MAX_RETRIES

--- a/src/token-processor/queue/job/job.ts
+++ b/src/token-processor/queue/job/job.ts
@@ -2,7 +2,7 @@ import { logger, resolveOrTimeout, stopwatch } from '@hirosystems/api-toolkit';
 import { ENV } from '../../../env';
 import { PgStore } from '../../../pg/pg-store';
 import { DbJob, DbJobInvalidReason, DbJobStatus } from '../../../pg/types';
-import { getUserErrorInvalidReason, UserError } from '../../util/errors';
+import { getUserErrorInvalidReason, TooManyRequestsHttpError, UserError } from '../../util/errors';
 import { RetryableJobError } from '../errors';
 import { getJobQueueProcessingMode, JobQueueProcessingMode } from '../helpers';
 
@@ -52,10 +52,16 @@ export abstract class Job {
       }
     } catch (error) {
       if (error instanceof RetryableJobError) {
-        const retries = await this.db.increaseJobRetryCount({
-          id: this.job.id,
-          retry_after: ENV.JOB_QUEUE_RETRY_AFTER_MS,
-        });
+        let retry_after = ENV.JOB_QUEUE_RETRY_AFTER_MS;
+        // If we got rate limited, save this host so we can skip further calls even from jobs for
+        // other tokens.
+        if (error.cause instanceof TooManyRequestsHttpError) {
+          await this.saveRateLimitedHost(error.cause);
+          if (error.cause.retryAfter) {
+            retry_after = error.cause.retryAfter * 1_000;
+          }
+        }
+        const retries = await this.db.increaseJobRetryCount({ id: this.job.id, retry_after });
         if (
           getJobQueueProcessingMode() === JobQueueProcessingMode.strict ||
           retries <= ENV.JOB_QUEUE_MAX_RETRIES
@@ -97,5 +103,12 @@ export abstract class Job {
       logger.error(`Job ${this.description()} could not update status to ${status}: ${error}`);
       return false;
     }
+  }
+
+  private async saveRateLimitedHost(error: TooManyRequestsHttpError) {
+    const hostname = error.url.hostname;
+    const retryAfter = error.retryAfter ?? ENV.METADATA_RATE_LIMITED_HOST_RETRY_AFTER;
+    logger.info(`Job saving rate limited host ${hostname}, retry after ${retryAfter}s`);
+    await this.db.insertRateLimitedHost({ values: { hostname, retry_after: retryAfter } });
   }
 }

--- a/tests/token-queue/job.test.ts
+++ b/tests/token-queue/job.test.ts
@@ -1,4 +1,4 @@
-import { cycleMigrations } from '@hirosystems/api-toolkit';
+import { cycleMigrations, timeout } from '@hirosystems/api-toolkit';
 import { ENV } from '../../src/env';
 import { MIGRATIONS_DIR, PgStore } from '../../src/pg/pg-store';
 import { DbJob, DbSipNumber, DbSmartContractInsert } from '../../src/pg/types';
@@ -64,14 +64,14 @@ describe('Job', () => {
     const job = new TestRetryableJob({ db, job: dbJob });
 
     await expect(job.work()).resolves.not.toThrow();
-    const jobs1 = await db.getPendingJobBatch({ limit: 1 });
-    expect(jobs1[0].retry_count).toBe(1);
-    expect(jobs1[0].status).toBe('pending');
+    const jobs1 = await db.getJob({ id: 1 });
+    expect(jobs1?.retry_count).toBe(1);
+    expect(jobs1?.status).toBe('pending');
 
     await expect(job.work()).resolves.not.toThrow();
-    const jobs2 = await db.getPendingJobBatch({ limit: 1 });
-    expect(jobs2[0].retry_count).toBe(2);
-    expect(jobs2[0].status).toBe('pending');
+    const jobs2 = await db.getJob({ id: 1 });
+    expect(jobs2?.retry_count).toBe(2);
+    expect(jobs2?.status).toBe('pending');
   });
 
   test('user error marks job invalid', async () => {
@@ -98,12 +98,26 @@ describe('Job', () => {
   test('strict mode ignores retry_count limit', async () => {
     ENV.JOB_QUEUE_STRICT_MODE = true;
     ENV.JOB_QUEUE_MAX_RETRIES = 0;
+    ENV.JOB_QUEUE_RETRY_AFTER_MS = 0;
     const job = new TestRetryableJob({ db, job: dbJob });
 
     await expect(job.work()).resolves.not.toThrow();
     const jobs1 = await db.getPendingJobBatch({ limit: 1 });
     expect(jobs1[0].retry_count).toBe(1);
     expect(jobs1[0].status).toBe('pending');
+  });
+
+  test('pending job batches consider retry_after', async () => {
+    ENV.JOB_QUEUE_RETRY_AFTER_MS = 200;
+    const job = new TestRetryableJob({ db, job: dbJob });
+
+    await expect(job.work()).resolves.not.toThrow();
+    const jobs1 = await db.getPendingJobBatch({ limit: 1 });
+    expect(jobs1).toHaveLength(0);
+
+    await timeout(300);
+    const jobs2 = await db.getPendingJobBatch({ limit: 1 });
+    expect(jobs2).toHaveLength(1);
   });
 
   test('db errors are not re-thrown', async () => {

--- a/tests/token-queue/process-token-job.test.ts
+++ b/tests/token-queue/process-token-job.test.ts
@@ -851,7 +851,7 @@ describe('ProcessTokenJob', () => {
         })
         .reply(429, { error: 'nope' }, { headers: { 'retry-after': '999' } });
       try {
-        await new ProcessTokenJob({ db, job: tokenJob }).handler();
+        await new ProcessTokenJob({ db, job: tokenJob }).work();
       } catch (error) {
         expect(error).toBeInstanceOf(RetryableJobError);
         const err = error as RetryableJobError;


### PR DESCRIPTION
Also, set a customized job retry delay when receiving a rate limit from a metadata host, so we don't enqueue the same job again if we're expecting to still be rate limited.

Fixes #84 