### PR TITLE
fix: allow boolean metadata properties

### DIFF
--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -189,7 +189,11 @@ export class PgStore extends BasePgStore {
           }
           if (locale.properties && locale.properties.length > 0) {
             const values = locale.properties.map(property => ({
-              ...property,
+              name: property.name,
+              value:
+                typeof property.value == 'boolean'
+                  ? sql`TO_JSONB(${property.value})`
+                  : property.value,
               metadata_id: metadataId,
             }));
             await sql`INSERT INTO metadata_properties ${sql(values)}`;

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -211,16 +211,14 @@ async function parseMetadataForInsertion(
     const properties: DbMetadataPropertyInsert[] = defaultInsert?.properties ?? [];
     if (RawMetadataPropertiesCType.Check(metadata.properties)) {
       for (const [key, value] of Object.entries(metadata.properties)) {
-        if (key && value) {
-          const defaultProp = properties.find(p => p.name === key);
-          if (defaultProp) {
-            defaultProp.value = value;
-          } else {
-            properties.push({
-              name: key,
-              value: value,
-            });
-          }
+        const defaultProp = properties.find(p => p.name === key);
+        if (defaultProp) {
+          defaultProp.value = value;
+        } else {
+          properties.push({
+            name: key,
+            value: value,
+          });
         }
       }
     }

--- a/tests/api/nft.test.ts
+++ b/tests/api/nft.test.ts
@@ -217,6 +217,10 @@ describe('NFT routes', () => {
                 name: 'prop2',
                 value: 1,
               },
+              {
+                name: 'prop3',
+                value: true,
+              },
             ],
           },
         ],
@@ -251,6 +255,7 @@ describe('NFT routes', () => {
         properties: {
           prop1: 'ABC',
           prop2: 1,
+          prop3: true,
         },
       },
     });

--- a/tests/token-queue/metadata-helpers.test.ts
+++ b/tests/token-queue/metadata-helpers.test.ts
@@ -60,7 +60,7 @@ describe('Metadata Helpers', () => {
     await expect(fetchMetadata(url, 'ABCD.test', 1n)).rejects.toThrow(MetadataHttpError);
   });
 
-  test('does not throw on raw metadata with null or stringable values', async () => {
+  test('does not throw on raw metadata with null, stringable, or boolean values', async () => {
     const crashPunks1 = {
       version: '1',
       name: 'Crash Punk 294',
@@ -74,6 +74,9 @@ describe('Metadata Helpers', () => {
         external_url:
           'https://thisisnumberone.com/nfts/SP3QSAJQ4EA8WXEDSRRKMZZ29NH91VZ6C5X88FGZQ.crashpunks-v2/294',
         animation_url: null,
+        allow_multiple_claims: true,
+        whitelisted: false,
+        minted: 160,
       },
       localization: {
         uri: null,

--- a/tests/token-queue/process-token-job.test.ts
+++ b/tests/token-queue/process-token-job.test.ts
@@ -382,6 +382,8 @@ describe('ProcessTokenJob', () => {
           collection_size: 5000,
           artist: 'Bitcoin Monkeys',
           prop: { a: 1, b: 2 },
+          allow_multiple_claims: true,
+          whitelisted: false,
         },
       };
       const agent = new MockAgent();
@@ -441,6 +443,10 @@ describe('ProcessTokenJob', () => {
       expect(properties[4].value).toBe(5000);
       expect(properties[6].name).toBe('prop');
       expect(properties[6].value).toStrictEqual({ a: 1, b: 2 });
+      expect(properties[7].name).toBe('allow_multiple_claims');
+      expect(properties[7].value).toStrictEqual(true);
+      expect(properties[8].name).toBe('whitelisted');
+      expect(properties[8].value).toStrictEqual(false);
     });
 
     test('parses metadata with localizations', async () => {


### PR DESCRIPTION
Fixes an error that prevented boolean properties from being saved
```
PostgresError: column "value" is of type jsonb but expression is of type boolean
    at ErrorResponse (/app/node_modules/postgres/cjs/src/connection.js:771:26)
    at handle (/app/node_modules/postgres/cjs/src/connection.js:473:6)
    at Socket.data (/app/node_modules/postgres/cjs/src/connection.js:314:9)
    at Socket.emit (node:events:519:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:191:23)
    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)
    at cachedError (/app/node_modules/postgres/cjs/src/query.js:171:23)
    at new Query (/app/node_modules/postgres/cjs/src/query.js:36:24)
    at sql (/app/node_modules/postgres/cjs/src/index.js:111:11)
    at /app/dist/src/pg/pg-store.js:136:35
```