### PR TITLE
fix: ignore events from failed transactions

### DIFF
--- a/src/pg/chainhook/block-cache.ts
+++ b/src/pg/chainhook/block-cache.ts
@@ -47,6 +47,7 @@ export class BlockCache {
   }
 
   transaction(tx: StacksTransaction) {
+    if (!tx.metadata.success) return;
     if (tx.metadata.kind.type === 'ContractDeployment' && tx.metadata.contract_abi) {
       const abi = tx.metadata.contract_abi as ClarityAbi;
       const sip = getSmartContractSip(abi);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1341,7 +1341,7 @@ export class TestChainhookPayloadBuilder {
     return this;
   }
 
-  transaction(args: { hash: string; sender?: string }): this {
+  transaction(args: { hash: string; sender?: string; success?: boolean }): this {
     this.lastBlock.transactions.push({
       metadata: {
         contract_abi: null,
@@ -1367,7 +1367,7 @@ export class TestChainhookPayloadBuilder {
         },
         result: '(ok true)',
         sender: args.sender ?? 'SP3HXJJMJQ06GNAZ8XWDN1QM48JEDC6PP6W3YZPZJ',
-        success: true,
+        success: args.success ?? true,
       },
       operations: [],
       transaction_identifier: {


### PR DESCRIPTION
Do not process any events from failed Stacks transactions.

Fixes #262 