### PR TITLE
Fix metrics default port for prometheus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     env:
       API_HOST: 127.0.0.1
       API_PORT: 3000
-      PROMETHEUS_PORT: 9154
+      PROMETHEUS_PORT: 9153
       PGHOST: 127.0.0.1
       PGPORT: 5432
       PGUSER: postgres

--- a/src/env.ts
+++ b/src/env.ts
@@ -28,7 +28,7 @@ const schema = Type.Object({
   /** Hostname that will be reported to the chainhook node so it can call us back with events */
   EXTERNAL_HOSTNAME: Type.String({ default: '127.0.0.1' }),
   /** Port in which to serve prometheus metrics */
-  PROMETHEUS_PORT: Type.Number({ default: 9154 }),
+  PROMETHEUS_PORT: Type.Number({ default: 9153 }),
   /** Port in which to serve the profiler */
   PROFILER_PORT: Type.Number({ default: 9119 }),
 


### PR DESCRIPTION
### Description

To get new alerts working the prometheus port needs to be fixed. https://github.com/hirosystems/devops/issues/1785
This issue looks to have been introduced on this commit --> https://github.com/hirosystems/token-metadata-api/commit/c769d2950d65448265caf2bf6bd78fce437358c0

#### Breaking change?

NA

### Example

