### PR TITLE
fix: update ft date on supply change

### DIFF
--- a/src/pg/chainhook/chainhook-pg-store.ts
+++ b/src/pg/chainhook/chainhook-pg-store.ts
@@ -243,7 +243,7 @@ export class ChainhookPgStore extends BasePgStoreModule {
   ): Promise<void> {
     await sql`
       UPDATE tokens
-      SET total_supply = total_supply + ${delta}
+      SET total_supply = total_supply + ${delta}, updated_at = NOW()
       WHERE smart_contract_id = (SELECT id FROM smart_contracts WHERE principal = ${contract})
         AND token_number = 1
     `;


### PR DESCRIPTION
This change makes sure the Etag for this token gets updated so supply changes can be reflected to clients properly