### PR TITLE
fix: update chainhook predicate start_block upon re-registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fastify/type-provider-typebox": "^3.2.0",
         "@google-cloud/storage": "^7.12.1",
         "@hirosystems/api-toolkit": "^1.7.1",
-        "@hirosystems/chainhook-client": "^2.0.0",
+        "@hirosystems/chainhook-client": "^2.4.0",
         "@sinclair/typebox": "^0.28.17",
         "@stacks/transactions": "^6.1.0",
         "@types/node": "^20.16.1",
@@ -2714,9 +2714,9 @@
       }
     },
     "node_modules/@hirosystems/chainhook-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hirosystems/chainhook-client/-/chainhook-client-2.0.0.tgz",
-      "integrity": "sha512-CZrByDwTr4Re5PBSlr7spHCRcdZLVf4D/wmuPmMdmJjreOohcwOBmSxKQG6kwMHbnBtcVXoI9rn1c96GoaNf6Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/chainhook-client/-/chainhook-client-2.4.0.tgz",
+      "integrity": "sha512-S+lekGeMqtEEPiEcvSSoqfO33V2/kMY8eAboULysddQ0KQx/z9RHn+iV2bU7J3lq8nkFAgBUCWaGNzuBVGY0yA==",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.2.0",
         "fastify": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@fastify/type-provider-typebox": "^3.2.0",
     "@google-cloud/storage": "^7.12.1",
     "@hirosystems/api-toolkit": "^1.7.1",
-    "@hirosystems/chainhook-client": "^2.0.0",
+    "@hirosystems/chainhook-client": "^2.4.0",
     "@sinclair/typebox": "^0.28.17",
     "@stacks/transactions": "^6.1.0",
     "@types/node": "^20.16.1",

--- a/src/chainhook/server.ts
+++ b/src/chainhook/server.ts
@@ -69,11 +69,13 @@ export async function startChainhookServer(args: { db: PgStore }): Promise<Chain
     node_type: 'chainhook',
     predicate_re_register_callback: async predicate => {
       const blockHeight = await args.db.getChainTipBlockHeight();
-      if (predicate.networks.mainnet) {
-        predicate.networks.mainnet.start_block = blockHeight;
-      }
-      if (predicate.networks.testnet) {
-        predicate.networks.testnet.start_block = blockHeight;
+      switch (ENV.NETWORK) {
+        case 'mainnet':
+          if (predicate.networks.mainnet) predicate.networks.mainnet.start_block = blockHeight;
+          break;
+        case 'testnet':
+          if (predicate.networks.testnet) predicate.networks.testnet.start_block = blockHeight;
+          break;
       }
       return predicate as Predicate;
     },

--- a/src/chainhook/server.ts
+++ b/src/chainhook/server.ts
@@ -4,6 +4,7 @@ import {
   EventObserverOptions,
   EventObserverPredicate,
   Payload,
+  Predicate,
   StacksPayload,
 } from '@hirosystems/chainhook-client';
 import { PgStore } from '../pg/pg-store';
@@ -66,6 +67,16 @@ export async function startChainhookServer(args: { db: PgStore }): Promise<Chain
     predicate_disk_file_path: ENV.CHAINHOOK_PREDICATE_PATH,
     predicate_health_check_interval_ms: 300_000,
     node_type: 'chainhook',
+    predicate_re_register_callback: async predicate => {
+      const blockHeight = await args.db.getChainTipBlockHeight();
+      if (predicate.networks.mainnet) {
+        predicate.networks.mainnet.start_block = blockHeight;
+      }
+      if (predicate.networks.testnet) {
+        predicate.networks.testnet.start_block = blockHeight;
+      }
+      return predicate as Predicate;
+    },
   };
   const chainhook: ChainhookNodeOptions = {
     base_url: `http://${ENV.CHAINHOOK_NODE_RPC_HOST}:${ENV.CHAINHOOK_NODE_RPC_PORT}`,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1290,6 +1290,7 @@ export class TestChainhookPayloadBuilder {
       },
       is_streaming_blocks: true,
     },
+    events: [],
   };
   private action: 'apply' | 'rollback' = 'apply';
   private get lastBlock(): StacksEvent {
@@ -1330,6 +1331,13 @@ export class TestChainhookPayloadBuilder {
         pox_cycle_length: 2100,
         pox_cycle_position: 1722,
         stacks_block_hash: '0xbccf63ec2438cf497786ce617ec7e64e2b27ee023a28a0927ee36b81870115d2',
+        tenure_height: null,
+        block_time: null,
+        signer_bitvec: null,
+        signer_signature: null,
+        signer_public_keys: null,
+        cycle_number: null,
+        reward_set: null,
       },
       parent_block_identifier: {
         hash: '0xca71af03f9a3012491af2f59f3244ecb241551803d641f8c8306ffa1187938b4',


### PR DESCRIPTION
If a chainhook predicate goes obsolete, update its starting block height on re-registration.

There is a bug on chainhook which sometimes marks active predicates as inactive, forcing the Metadata API to re-register so it receives blocks again. However, since we weren't updating the re-registration starting block height, we ended up in an infinite loop that made us receive blocks from the last block height seen on boot. This caused the API to fall significantly behind chain tip.