### PR TITLE
feat: add `/import-contract` admin rpc endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "eslint-plugin-tsdoc": "^0.2.17",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
+        "nock": "^14.0.5",
         "openapi-typescript": "^7.4.1",
         "prettier": "^2.7.1",
         "redoc-cli": "^0.13.20",
@@ -4044,6 +4045,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.38.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.38.7.tgz",
+      "integrity": "sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
@@ -4100,6 +4118,28 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@redocly/ajv": {
       "version": "8.11.2",
@@ -8716,6 +8756,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -10697,6 +10743,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11191,6 +11243,20 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/nock": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.5.tgz",
+      "integrity": "sha512-R49fALR9caB6vxuSWUIaK2eBYeTloZQUFBZ4rHO+TbhMGQHtwnhdqKLYki+o+8qMgLvoBYWrp/2KzGPhxL4S6w==",
+      "dev": true,
+      "dependencies": {
+        "@mswjs/interceptors": "^0.38.7",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -11512,6 +11578,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -11991,6 +12063,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -17139,6 +17220,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@hirosystems/api-toolkit": "^1.7.1",
         "@hirosystems/chainhook-client": "^2.4.0",
         "@sinclair/typebox": "^0.28.17",
+        "@stacks/blockchain-api-client": "^8.11.1",
         "@stacks/transactions": "^6.1.0",
         "@types/node": "^20.16.1",
         "bignumber.js": "^9.1.2",
@@ -4186,6 +4187,36 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "node_modules/@stacks/blockchain-api-client": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@stacks/blockchain-api-client/-/blockchain-api-client-8.11.1.tgz",
+      "integrity": "sha512-yVMsyEOTSvozy1J3/456Cu7kL01ObkBIG0YEjptXs5G2lBXUf25isYXhmkxiD1NtnpjWFE2zdxvJwOrU7kclxw==",
+      "dependencies": {
+        "@types/node": "20.14.14",
+        "eventemitter3": "^4.0.7",
+        "jsonrpc-lite": "^2.2.0",
+        "openapi-fetch": "^0.10.5",
+        "socket.io-client": "^4.7.5"
+      }
+    },
+    "node_modules/@stacks/blockchain-api-client/node_modules/@types/node": {
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@stacks/blockchain-api-client/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/@stacks/common": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.0.0.tgz",
@@ -6706,6 +6737,26 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/enquirer": {
@@ -10678,6 +10729,11 @@
         "node >= 0.2.0"
       ]
     },
+    "node_modules/jsonrpc-lite": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jsonrpc-lite/-/jsonrpc-lite-2.2.0.tgz",
+      "integrity": "sha512-/cbbSxtZWs1O7R4tWqabrCM/t3N8qKUZMAg9IUqpPvUs6UyRvm6pCNYkskyKN/XU0UgffW+NY2ZRr8t0AknX7g=="
+    },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -11361,6 +11417,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.10.6.tgz",
+      "integrity": "sha512-6xXfvIEL/POtLGOaFPsp3O+pDe+J3DZYxbD9BrsQHXOTeNK8z/gsWHT6adUy1KcpQOhmkerMzlQrJM6DbN55dQ==",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.11"
+      }
+    },
     "node_modules/openapi-types": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.2.tgz",
@@ -11385,6 +11449,11 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.11.tgz",
+      "integrity": "sha512-xofUHlVFq+BMquf3nh9I8N2guHckW6mrDO/F3kaFgrL7MGbjldDnQ9TIT+rkH/+H0LiuO+RuZLnNmsJwsjwUKg=="
     },
     "node_modules/openapi-typescript/node_modules/parse-json": {
       "version": "8.1.0",
@@ -16916,6 +16985,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
@@ -17935,6 +18030,34 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@hirosystems/api-toolkit": "^1.7.1",
     "@hirosystems/chainhook-client": "^2.4.0",
     "@sinclair/typebox": "^0.28.17",
+    "@stacks/blockchain-api-client": "^8.11.1",
     "@stacks/transactions": "^6.1.0",
     "@types/node": "^20.16.1",
     "bignumber.js": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-tsdoc": "^0.2.17",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
+    "nock": "^14.0.5",
     "openapi-typescript": "^7.4.1",
     "prettier": "^2.7.1",
     "redoc-cli": "^0.13.20",

--- a/src/admin-rpc/init.ts
+++ b/src/admin-rpc/init.ts
@@ -142,7 +142,7 @@ export const AdminApi: FastifyPluginCallback<Record<never, never>, Server, TypeB
     },
     async (request, reply) => {
       // Look for the contract in the Stacks Blockchain API.
-      const api = createClient({ baseUrl: 'https://api.mainnet.hiro.so' });
+      const api = createClient({ baseUrl: ENV.STACKS_API_BASE_URL });
       const { data: contract } = await api.GET('/extended/v1/contract/{contract_id}', {
         params: { path: { contract_id: request.body.contractId } },
       });

--- a/src/admin-rpc/init.ts
+++ b/src/admin-rpc/init.ts
@@ -8,6 +8,9 @@ import { logger, PINO_LOGGER_CONFIG } from '@hirosystems/api-toolkit';
 import { reprocessTokenImageCache } from '../token-processor/images/image-cache';
 import { ENV } from '../env';
 import { JobQueue } from '../token-processor/queue/job-queue';
+import { createClient } from '@stacks/blockchain-api-client';
+import { ClarityAbi } from '@stacks/transactions';
+import { getSmartContractSip } from '../token-processor/util/sip-validation';
 
 export const AdminApi: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (
   fastify,
@@ -122,6 +125,76 @@ export const AdminApi: FastifyPluginCallback<Record<never, never>, Server, TypeB
       }
       void jobQueue.stop();
       return reply.code(200).send();
+    }
+  );
+
+  fastify.post(
+    '/import-contract',
+    {
+      schema: {
+        description:
+          'Imports a smart contract from the Stacks API and refreshes its token metadata',
+        body: Type.Object({
+          contractId: Type.RegEx(SmartContractRegEx),
+          tokenIds: Type.Optional(Type.Array(Type.Integer())),
+        }),
+      },
+    },
+    async (request, reply) => {
+      // Look for the contract in the Stacks Blockchain API.
+      const api = createClient({ baseUrl: 'https://api.mainnet.hiro.so' });
+      const { data: contract } = await api.GET('/extended/v1/contract/{contract_id}', {
+        params: { path: { contract_id: request.body.contractId } },
+      });
+      if (!contract) {
+        await reply.code(422).send({ error: 'Contract not found' });
+        return;
+      }
+      if (!contract.abi) {
+        await reply.code(422).send({ error: 'Contract does not have an interface' });
+        return;
+      }
+
+      // Make sure it's a token contract.
+      const abi = JSON.parse(contract.abi) as ClarityAbi;
+      const sip = getSmartContractSip(abi);
+      if (!sip) {
+        await reply.code(422).send({ error: 'Not a token contract' });
+        return;
+      }
+
+      // Get transaction and block data.
+      const { data: transaction } = await api.GET('/extended/v1/tx/{tx_id}', {
+        params: { path: { tx_id: contract.tx_id } },
+      });
+      if (!transaction) {
+        await reply.code(422).send({ error: 'Contract deploy transaction not found' });
+        return;
+      }
+      const { data: block } = await api.GET('/extended/v2/blocks/{height_or_hash}', {
+        params: { path: { height_or_hash: contract.block_height } },
+      });
+      if (!block) {
+        await reply.code(422).send({ error: 'Contract deploy block not found' });
+        return;
+      }
+
+      // Enqueue contract for processing.
+      await fastify.db.sqlWriteTransaction(async sql => {
+        await fastify.db.chainhook.enqueueContract(sql, {
+          block_height: contract.block_height,
+          index_block_hash: block.index_block_hash,
+          principal: contract.contract_id,
+          sip,
+          tx_id: contract.tx_id,
+          // We need to convert to `any` first because there's a bug in the Stacks API types
+          // library that causes TS to incorrectly think `tx_index` is not available in the
+          // transaction response.
+          tx_index: (transaction as any).tx_index,
+          fungible_token_name: abi.fungible_tokens[0]?.name ?? null,
+          non_fungible_token_name: abi.non_fungible_tokens[0]?.name ?? null,
+        });
+      });
     }
   );
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -66,6 +66,9 @@ const schema = Type.Object({
   STACKS_NODE_RPC_HOST: Type.String(),
   STACKS_NODE_RPC_PORT: Type.Number({ minimum: 0, maximum: 65535 }),
 
+  /// Base url for the Stacks API. Used only through AdminRPC requests for maintenance operations.
+  STACKS_API_BASE_URL: Type.String({ default: 'https://api.mainnet.hiro.so' }),
+
   /** Whether or not the job queue should start processing jobs immediately after bootup. */
   JOB_QUEUE_AUTO_START: Type.Boolean({ default: true }),
   /** Whether or not the `JobQueue` will continue to try retryable failed jobs indefinitely. */


### PR DESCRIPTION
Add endpoint to import a smart contract on demand. The endpoint will pull data from the Stacks API (configurable via ENV) and it will validate if it's a token contract. If it is, it will enqueue it to pull all of its tokens and metadata.