### PR TITLE
fix: replace hard coded IPFS gateways with configurable gateway

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -132,12 +132,18 @@ const schema = Type.Object({
    */
   PUBLIC_GATEWAY_IPFS: Type.String({ default: 'https://cloudflare-ipfs.com' }),
   /**
+   * Extra header key to add to the request when fetching metadata from the configured IPFS gateway,
+   * for example if authentication is required. Must be in the form 'Header: Value'.
+   */
+  PUBLIC_GATEWAY_IPFS_EXTRA_HEADER: Type.Optional(Type.String()),
+  /**
    * List of public IPFS gateways that will be replaced with the value of `PUBLIC_GATEWAY_IPFS`
    * whenever a metadata URL has these gateways hard coded in `http:` or `https:` URLs.
    */
   PUBLIC_GATEWAY_IPFS_REPLACED: Type.String({
     default: 'ipfs.io,dweb.link,gateway.pinata.cloud,cloudflare-ipfs.com,infura-ipfs.io',
   }),
+
   /**
    * Base URL for a public gateway which will provide access to all Arweave resources when metadata
    * URLs use the `ar:` protocol scheme. Defaults to

--- a/src/env.ts
+++ b/src/env.ts
@@ -127,12 +127,20 @@ const schema = Type.Object({
   METADATA_FETCH_MAX_REDIRECTIONS: Type.Number({ default: 5 }),
 
   /**
-   * Base URL for a public gateway which will provide access to all IPFS resources. Defaults to
-   * `https://cloudflare-ipfs.com`.
+   * Base URL for a public gateway which will provide access to all IPFS resources when metadata
+   * URLs use the `ipfs:` or `ipns:` protocol schemes. Defaults to `https://cloudflare-ipfs.com`.
    */
   PUBLIC_GATEWAY_IPFS: Type.String({ default: 'https://cloudflare-ipfs.com' }),
   /**
-   * Base URL for a public gateway which will provide access to all Arweave resources. Defaults to
+   * List of public IPFS gateways that will be replaced with the value of `PUBLIC_GATEWAY_IPFS`
+   * whenever a metadata URL has these gateways hard coded in `http:` or `https:` URLs.
+   */
+  PUBLIC_GATEWAY_IPFS_REPLACED: Type.String({
+    default: 'ipfs.io,dweb.link,gateway.pinata.cloud,cloudflare-ipfs.com,infura-ipfs.io',
+  }),
+  /**
+   * Base URL for a public gateway which will provide access to all Arweave resources when metadata
+   * URLs use the `ar:` protocol scheme. Defaults to
    * `https://arweave.net`.
    */
   PUBLIC_GATEWAY_ARWEAVE: Type.String({ default: 'https://arweave.net' }),

--- a/src/token-processor/queue/job/process-token-job.ts
+++ b/src/token-processor/queue/job/process-token-job.ts
@@ -12,7 +12,7 @@ import { StacksNodeRpcClient } from '../../stacks-node/stacks-node-rpc-client';
 import { SmartContractClarityError, TooManyRequestsHttpError } from '../../util/errors';
 import {
   fetchAllMetadataLocalesFromBaseUri,
-  getFetchableDecentralizedStorageUrl,
+  getFetchableMetadataUrl,
   getTokenSpecificUri,
 } from '../../util/metadata-helpers';
 import { RetryableJobError } from '../errors';
@@ -194,7 +194,7 @@ export class ProcessTokenJob extends Job {
       return;
     }
     // Before we return the uri, check if its fetchable hostname is not already rate limited.
-    const fetchable = getFetchableDecentralizedStorageUrl(uri);
+    const fetchable = getFetchableMetadataUrl(uri).url;
     const rateLimitedHost = await this.db.getRateLimitedHost({ hostname: fetchable.hostname });
     if (rateLimitedHost) {
       const retryAfter = Date.parse(rateLimitedHost.retry_after);

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -40,6 +40,8 @@ const METADATA_FETCH_HTTP_AGENT = new Agent({
   },
 });
 
+const PUBLIC_GATEWAY_IPFS_REPLACED = ENV.PUBLIC_GATEWAY_IPFS_REPLACED.split(',');
+
 /**
  * Fetches all the localized metadata JSONs for a token. First, it downloads the default metadata
  * JSON and parses it looking for other localizations. If those are found, each of them is then
@@ -344,15 +346,8 @@ export function getFetchableDecentralizedStorageUrl(uri: string): URL {
   try {
     const parsedUri = new URL(uri);
     if (parsedUri.protocol === 'http:' || parsedUri.protocol === 'https:') {
-      // Check if this is a public IPFS gateway and replace with ENV.PUBLIC_GATEWAY_IPFS
-      const publicIpfsGateways = [
-        'ipfs.io',
-        'dweb.link',
-        'gateway.pinata.cloud',
-        'cloudflare-ipfs.com',
-        'infura-ipfs.io',
-      ];
-      if (publicIpfsGateways.includes(parsedUri.hostname)) {
+      // If this is a known public IPFS gateway, replace it with `ENV.PUBLIC_GATEWAY_IPFS`.
+      if (PUBLIC_GATEWAY_IPFS_REPLACED.includes(parsedUri.hostname)) {
         return new URL(`${ENV.PUBLIC_GATEWAY_IPFS}${parsedUri.pathname}`);
       }
       return parsedUri;

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -40,13 +40,21 @@ const METADATA_FETCH_HTTP_AGENT = new Agent({
   },
 });
 
-const PUBLIC_GATEWAY_IPFS_REPLACED = ENV.PUBLIC_GATEWAY_IPFS_REPLACED.split(',');
-
+/**
+ * A metadata URL that was analyzed and normalized into a fetchable URL. Specifies the URL, the
+ * gateway type, and any extra headers that may be required to fetch the metadata.
+ */
 export type FetchableMetadataUrl = {
   url: URL;
   gateway: 'ipfs' | 'arweave' | null;
   fetchHeaders?: Record<string, string>;
 };
+
+/**
+ * List of public IPFS gateways that will be replaced with the value of `ENV.PUBLIC_GATEWAY_IPFS`
+ * whenever a metadata URL has these gateways hard coded in `http:` or `https:` URLs.
+ */
+const PUBLIC_GATEWAY_IPFS_REPLACED = ENV.PUBLIC_GATEWAY_IPFS_REPLACED.split(',');
 
 /**
  * Fetches all the localized metadata JSONs for a token. First, it downloads the default metadata
@@ -358,7 +366,7 @@ export function getFetchableMetadataUrl(uri: string): FetchableMetadataUrl {
     const result: FetchableMetadataUrl = {
       url: parsedUri,
       gateway: null,
-      fetchHeaders: {},
+      fetchHeaders: undefined,
     };
     if (parsedUri.protocol === 'http:' || parsedUri.protocol === 'https:') {
       // If this is a known public IPFS gateway, replace it with `ENV.PUBLIC_GATEWAY_IPFS`.

--- a/tests/token-queue/metadata-helpers.test.ts
+++ b/tests/token-queue/metadata-helpers.test.ts
@@ -222,6 +222,10 @@ describe('Metadata Helpers', () => {
     expect(getFetchableDecentralizedStorageUrl(ipfs2).toString()).toBe(
       'https://cloudflare-ipfs.com/ipfs/QmYCnfeseno5cLpC75rmy6LQhsNYQCJabiuwqNUXMaA3Fo/1145.png'
     );
+    const ipfs3 = 'https://ipfs.io/ipfs/QmYCnfeseno5cLpC75rmy6LQhsNYQCJabiuwqNUXMaA3Fo/1145.png';
+    expect(getFetchableDecentralizedStorageUrl(ipfs3).toString()).toBe(
+      'https://cloudflare-ipfs.com/ipfs/QmYCnfeseno5cLpC75rmy6LQhsNYQCJabiuwqNUXMaA3Fo/1145.png'
+    );
   });
 
   test('replace URI string tokens', () => {


### PR DESCRIPTION
If a token metadata URI comes with a hard coded IPFS gateway (like `https://ipfs.io/ipfs/...`), replace it with our configured value for `ENV.PUBLIC_GATEWAY_IPFS`. This makes sure we can handle cases where our cloud servers get rate limited or black listed by gateways.