### PR TITLE
feat: upgrade @stacks/codec to 2.1.0 for pox-5 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
 
       - name: Cache node modules
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
           cache-name: cache-node-modules
         with:
@@ -72,17 +72,17 @@ jobs:
       STACKS_NODE_RPC_PORT: 24440
       SNP_REDIS_URL: redis://localhost:6379
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
 
       - name: Cache node modules
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
           cache-name: cache-node-modules
         with:
@@ -102,7 +102,7 @@ jobs:
         run: npx c8 --reporter=lcov npm run test:${{ matrix.suite }}
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -112,12 +112,12 @@ jobs:
     outputs:
       next_version: ${{ steps.calc.outputs.next_version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
 
@@ -160,19 +160,19 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Docker Meta
         id: docker_meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -180,7 +180,7 @@ jobs:
             type=ref,event=pr
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -188,7 +188,7 @@ jobs:
 
       - name: Build/Tag/Push Image
         id: docker_push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: v${{ inputs.version }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
 
@@ -44,19 +44,19 @@ jobs:
       packages: write
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: v${{ inputs.version }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -66,14 +66,14 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(inputs.version, '-') }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build/Tag/Push Image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -87,7 +87,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: v${{ inputs.version }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@sinclair/typebox": "^0.34.48",
         "@stacks/api-toolkit": "^1.13.0",
         "@stacks/blockchain-api-client": "^8.14.2",
-        "@stacks/codec": "^1.6.0",
+        "@stacks/codec": "^2.0.0",
         "@stacks/node-publisher-client": "^2.0.5",
         "@stacks/transactions": "^7.4.0",
         "@types/node": "^24.0.0",
@@ -3675,20 +3675,17 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/@stacks/codec": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@stacks/codec/-/codec-1.6.0.tgz",
-      "integrity": "sha512-X7LGOKl/GsX2bE+V+eiYOXoBA8CzymyvqTkLCV9yP+z8HqGiQnpP2pkerAb7YfZHtNCCJoWivY6eNViRCFd1nQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stacks/codec/-/codec-2.0.0.tgz",
+      "integrity": "sha512-ziiiK4IObv5dcJUaVZ3iYtM7nYL8MhsgS7tSAb6bhb3k5NU3JUqP4c7dkt8pdPy1jX69WIVOiY3PtHb2Uk5LMw==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@types/node": "^16.11.26",
+        "@types/node": "^24.0.0",
         "detect-libc": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
-    },
-    "node_modules/@stacks/codec/node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "license": "MIT"
     },
     "node_modules/@stacks/common": {
       "version": "7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@sinclair/typebox": "^0.34.48",
         "@stacks/api-toolkit": "^1.13.0",
         "@stacks/blockchain-api-client": "^8.14.2",
-        "@stacks/codec": "^2.0.0",
+        "@stacks/codec": "^2.1.0",
         "@stacks/node-publisher-client": "^2.0.5",
         "@stacks/transactions": "^7.4.0",
         "@types/node": "^24.0.0",
@@ -3675,9 +3675,9 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/@stacks/codec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@stacks/codec/-/codec-2.0.0.tgz",
-      "integrity": "sha512-ziiiK4IObv5dcJUaVZ3iYtM7nYL8MhsgS7tSAb6bhb3k5NU3JUqP4c7dkt8pdPy1jX69WIVOiY3PtHb2Uk5LMw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stacks/codec/-/codec-2.1.0.tgz",
+      "integrity": "sha512-RzI3UQ5oNXjcO1we2e6qq5/27+SosrmX2gZZxSi6VPTB26bTUxBY1/z1wxnJ820xu7xTg6Bhf8ssNkkZlcsz0A==",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@sinclair/typebox": "^0.34.48",
     "@stacks/api-toolkit": "^1.13.0",
     "@stacks/blockchain-api-client": "^8.14.2",
-    "@stacks/codec": "^2.0.0",
+    "@stacks/codec": "^2.1.0",
     "@stacks/node-publisher-client": "^2.0.5",
     "@stacks/transactions": "^7.4.0",
     "@types/node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@sinclair/typebox": "^0.34.48",
     "@stacks/api-toolkit": "^1.13.0",
     "@stacks/blockchain-api-client": "^8.14.2",
-    "@stacks/codec": "^1.6.0",
+    "@stacks/codec": "^2.0.0",
     "@stacks/node-publisher-client": "^2.0.5",
     "@stacks/transactions": "^7.4.0",
     "@types/node": "^24.0.0",

--- a/src/stacks-core/stacks-core-block-processor.ts
+++ b/src/stacks-core/stacks-core-block-processor.ts
@@ -8,7 +8,12 @@ import {
   SmartContractDeployment,
   TokenMetadataUpdateNotification,
 } from '../token-processor/util/sip-validation.js';
-import codec from '@stacks/codec';
+import {
+  ClarityTypeID,
+  DecodedTxResult,
+  decodeClarityValue,
+  decodeTransaction,
+} from '@stacks/codec';
 import { StacksCorePgStore } from '../pg/stacks-core-pg-store.js';
 import { logger, stopwatch } from '@stacks/api-toolkit';
 import {
@@ -24,7 +29,7 @@ import {
 
 export type DecodedStacksTransaction = {
   tx: NewBlockTransaction;
-  decoded: codec.DecodedTxResult;
+  decoded: DecodedTxResult;
   events: NewBlockEvent[];
 };
 
@@ -53,7 +58,7 @@ export function decodeStacksCoreBlock(block: NewBlockMessage): DecodedStacksBloc
     if (tx.burnchain_op) continue;
     transactions.push({
       tx,
-      decoded: codec.decodeTransaction(tx.raw_tx.substring(2)),
+      decoded: decodeTransaction(tx.raw_tx.substring(2)),
       events: (events.get(tx.txid) || []).sort((a, b) => a.event_index - b.event_index),
     });
   }
@@ -228,8 +233,8 @@ export class StacksCoreBlockProcessor {
     event: NewBlockNftMintEvent,
     nftMints: NftMintEvent[]
   ) {
-    const value = codec.decodeClarityValue(event.nft_mint_event.raw_value);
-    if (value.type_id === codec.ClarityTypeID.UInt) {
+    const value = decodeClarityValue(event.nft_mint_event.raw_value);
+    if (value.type_id === ClarityTypeID.UInt) {
       const principal = event.nft_mint_event.asset_identifier.split('::')[0];
       const tokenId = BigInt(value.value);
       nftMints.push({

--- a/src/token-processor/queue/job/process-token-job.ts
+++ b/src/token-processor/queue/job/process-token-job.ts
@@ -1,5 +1,5 @@
 import { cvToHex, uintCV } from '@stacks/transactions';
-import codec from '@stacks/codec';
+import { ClarityValueUInt, decodeClarityValueToRepr } from '@stacks/codec';
 import {
   DbMetadataLocaleInsertBundle,
   DbProcessedTokenUpdateBundle,
@@ -216,13 +216,13 @@ export class ProcessTokenJob extends Job {
     }
   }
 
-  private uIntCv(n: bigint): codec.ClarityValueUInt {
+  private uIntCv(n: bigint): ClarityValueUInt {
     const cv = uintCV(n);
     const hex = cvToHex(cv);
     return {
       value: n.toString(),
       hex: hex,
-      repr: codec.decodeClarityValueToRepr(hex),
-    } as codec.ClarityValueUInt;
+      repr: decodeClarityValueToRepr(hex),
+    } as ClarityValueUInt;
   }
 }

--- a/src/token-processor/queue/job/update-token-supply-job.ts
+++ b/src/token-processor/queue/job/update-token-supply-job.ts
@@ -1,5 +1,5 @@
 import { cvToHex, uintCV } from '@stacks/transactions';
-import codec from '@stacks/codec';
+import { ClarityValueUInt, decodeClarityValueToRepr } from '@stacks/codec';
 import { DbSmartContract, DbToken, DbTokenType } from '../../../pg/types.js';
 import { StacksNodeRpcClient } from '../../stacks-node/stacks-node-rpc-client.js';
 import { SmartContractClarityError, UserError } from '../../util/errors.js';
@@ -83,7 +83,7 @@ export class UpdateTokenSupplyJob extends Job {
   private async updateTokenSupply(
     client: StacksNodeRpcClient,
     token: DbToken,
-    arg: codec.ClarityValueUInt[] = []
+    arg: ClarityValueUInt[] = []
   ) {
     let fTotalSupply: PgNumeric | undefined;
     try {
@@ -103,13 +103,13 @@ export class UpdateTokenSupplyJob extends Job {
     await this.db.core.updateTokenSupply({ id: token.id, total_supply: fTotalSupply });
   }
 
-  private uIntCv(n: bigint): codec.ClarityValueUInt {
+  private uIntCv(n: bigint): ClarityValueUInt {
     const cv = uintCV(n);
     const hex = cvToHex(cv);
     return {
       value: n.toString(),
       hex: hex,
-      repr: codec.decodeClarityValueToRepr(hex),
-    } as codec.ClarityValueUInt;
+      repr: decodeClarityValueToRepr(hex),
+    } as ClarityValueUInt;
   }
 }

--- a/src/token-processor/stacks-node/stacks-node-rpc-client.ts
+++ b/src/token-processor/stacks-node/stacks-node-rpc-client.ts
@@ -1,4 +1,4 @@
-import codec from '@stacks/codec';
+import { ClarityTypeID, ClarityValue, ClarityValueUInt, decodeClarityValue } from '@stacks/codec';
 import { request, errors } from 'undici';
 import { ENV } from '../../env.js';
 import { RetryableJobError } from '../queue/errors.js';
@@ -55,7 +55,7 @@ export class StacksNodeRpcClient {
 
   async readStringFromContract(
     functionName: string,
-    functionArgs: codec.ClarityValue[] = []
+    functionArgs: ClarityValue[] = []
   ): Promise<string | undefined> {
     const clarityValue = await this.makeReadOnlyContractCall(functionName, functionArgs);
     return this.checkAndParseString(clarityValue);
@@ -63,7 +63,7 @@ export class StacksNodeRpcClient {
 
   async readUIntFromContract(
     functionName: string,
-    functionArgs: codec.ClarityValue[] = []
+    functionArgs: ClarityValue[] = []
   ): Promise<bigint | undefined> {
     const clarityValue = await this.makeReadOnlyContractCall(functionName, functionArgs);
     const uintVal = this.checkAndParseUintCV(clarityValue);
@@ -101,7 +101,7 @@ export class StacksNodeRpcClient {
 
   private async sendReadOnlyContractCall(
     functionName: string,
-    functionArgs: codec.ClarityValue[]
+    functionArgs: ClarityValue[]
   ): Promise<ReadOnlyContractCallResponse> {
     const body = {
       sender: this.senderAddress,
@@ -135,8 +135,8 @@ export class StacksNodeRpcClient {
 
   private async makeReadOnlyContractCall(
     functionName: string,
-    functionArgs: codec.ClarityValue[]
-  ): Promise<codec.ClarityValue> {
+    functionArgs: ClarityValue[]
+  ): Promise<ClarityValue> {
     const result = await this.sendReadOnlyContractCall(functionName, functionArgs);
     if (!result.okay) {
       if (result.cause.startsWith('Runtime')) {
@@ -150,23 +150,23 @@ export class StacksNodeRpcClient {
       }
       throw new SmartContractClarityError(`Read-only error ${functionName}: ${result.cause}`);
     }
-    return codec.decodeClarityValue(result.result);
+    return decodeClarityValue(result.result);
   }
 
-  private unwrapClarityType(clarityValue: codec.ClarityValue): codec.ClarityValue {
-    let unwrappedClarityValue: codec.ClarityValue = clarityValue;
+  private unwrapClarityType(clarityValue: ClarityValue): ClarityValue {
+    let unwrappedClarityValue: ClarityValue = clarityValue;
     while (
-      unwrappedClarityValue.type_id === codec.ClarityTypeID.ResponseOk ||
-      unwrappedClarityValue.type_id === codec.ClarityTypeID.OptionalSome
+      unwrappedClarityValue.type_id === ClarityTypeID.ResponseOk ||
+      unwrappedClarityValue.type_id === ClarityTypeID.OptionalSome
     ) {
       unwrappedClarityValue = unwrappedClarityValue.value;
     }
     return unwrappedClarityValue;
   }
 
-  private checkAndParseUintCV(responseCV: codec.ClarityValue): codec.ClarityValueUInt {
+  private checkAndParseUintCV(responseCV: ClarityValue): ClarityValueUInt {
     const unwrappedClarityValue = this.unwrapClarityType(responseCV);
-    if (unwrappedClarityValue.type_id === codec.ClarityTypeID.UInt) {
+    if (unwrappedClarityValue.type_id === ClarityTypeID.UInt) {
       return unwrappedClarityValue;
     }
     throw new SmartContractClarityError(
@@ -174,14 +174,14 @@ export class StacksNodeRpcClient {
     );
   }
 
-  private checkAndParseString(responseCV: codec.ClarityValue): string | undefined {
+  private checkAndParseString(responseCV: ClarityValue): string | undefined {
     const unwrappedClarityValue = this.unwrapClarityType(responseCV);
     if (
-      unwrappedClarityValue.type_id === codec.ClarityTypeID.StringAscii ||
-      unwrappedClarityValue.type_id === codec.ClarityTypeID.StringUtf8
+      unwrappedClarityValue.type_id === ClarityTypeID.StringAscii ||
+      unwrappedClarityValue.type_id === ClarityTypeID.StringUtf8
     ) {
       return unwrappedClarityValue.data;
-    } else if (unwrappedClarityValue.type_id === codec.ClarityTypeID.OptionalNone) {
+    } else if (unwrappedClarityValue.type_id === ClarityTypeID.OptionalNone) {
       return undefined;
     }
     throw new SmartContractClarityError(

--- a/src/token-processor/util/sip-validation.ts
+++ b/src/token-processor/util/sip-validation.ts
@@ -1,5 +1,13 @@
 import { ClarityAbiFunction, ClarityAbi } from '@stacks/transactions';
-import codec from '@stacks/codec';
+import {
+  ClarityTypeID,
+  ClarityValue,
+  ClarityValueList,
+  ClarityValueTuple,
+  ClarityValueUInt,
+  decodeClarityValue,
+  TxPayloadTypeID,
+} from '@stacks/codec';
 import { DbSipNumber } from '../../pg/types.js';
 import { DecodedStacksTransaction } from '../../stacks-core/stacks-core-block-processor.js';
 import { NewBlockContractEvent } from '@stacks/node-publisher-client';
@@ -247,19 +255,19 @@ function findFunction(fun: ClarityAbiFunction, functionList: ClarityAbiFunction[
   return found !== undefined;
 }
 
-function stringFromValue(value: codec.ClarityValue): string {
+function stringFromValue(value: ClarityValue): string {
   switch (value.type_id) {
-    case codec.ClarityTypeID.Buffer: {
+    case ClarityTypeID.Buffer: {
       const parts = value.buffer.substring(2).match(/.{1,2}/g) ?? [];
       const arr = Uint8Array.from(parts.map(byte => parseInt(byte, 16)));
       return Buffer.from(arr).toString('utf8');
     }
-    case codec.ClarityTypeID.StringAscii:
-    case codec.ClarityTypeID.StringUtf8:
+    case ClarityTypeID.StringAscii:
+    case ClarityTypeID.StringUtf8:
       return value.data;
-    case codec.ClarityTypeID.PrincipalContract:
+    case ClarityTypeID.PrincipalContract:
       return `${value.address}.${value.contract_name}`;
-    case codec.ClarityTypeID.PrincipalStandard:
+    case ClarityTypeID.PrincipalStandard:
       return value.address;
     default:
       throw new Error('Invalid clarity value');
@@ -324,12 +332,12 @@ export function getContractLogMetadataUpdateNotification(
   const sender = transaction.decoded.auth.origin_condition.signer.address;
   try {
     // Validate that we have the correct SIP-019 payload structure.
-    const value = codec.decodeClarityValue<codec.ClarityValueTuple>(log.raw_value);
+    const value = decodeClarityValue<ClarityValueTuple>(log.raw_value);
     const notification = stringFromValue(value.data.notification);
     if (notification !== 'token-metadata-update') {
       return;
     }
-    const payload = value.data.payload as codec.ClarityValueTuple;
+    const payload = value.data.payload as ClarityValueTuple;
     const contractId = stringFromValue(payload.data['contract-id']);
     const tokenClass = stringFromValue(payload.data['token-class']);
     if (!['ft', 'nft'].includes(tokenClass)) {
@@ -349,9 +357,7 @@ export function getContractLogMetadataUpdateNotification(
     // Only NFT notifications provide token ids.
     let tokenIds: bigint[] | undefined;
     if (tokenClass === 'nft') {
-      const tokenIdList = payload.data[
-        'token-ids'
-      ] as codec.ClarityValueList<codec.ClarityValueUInt>;
+      const tokenIdList = payload.data['token-ids'] as ClarityValueList<ClarityValueUInt>;
       if (tokenIdList) {
         tokenIds = tokenIdList.list.map(i => BigInt(i.value));
       }
@@ -368,7 +374,7 @@ export function getContractLogMetadataUpdateNotification(
 
     let ttl: bigint | undefined;
     const ttlValue = payload.data['ttl'];
-    if (ttlValue && ttlValue.type_id === codec.ClarityTypeID.UInt) {
+    if (ttlValue && ttlValue.type_id === ClarityTypeID.UInt) {
       ttl = BigInt(ttlValue.value);
     }
 
@@ -394,14 +400,14 @@ export function getContractLogSftMintEvent(
   const log = event.contract_event;
   try {
     // Validate that we have the correct SIP-013 `sft_mint` payload structure.
-    const value = codec.decodeClarityValue<codec.ClarityValueTuple>(log.raw_value);
+    const value = decodeClarityValue<ClarityValueTuple>(log.raw_value);
     const type = stringFromValue(value.data.type);
     if (type !== 'sft_mint') {
       return;
     }
     const recipient = stringFromValue(value.data['recipient']);
-    const tokenId = (value.data['token-id'] as codec.ClarityValueUInt).value;
-    const amount = (value.data['amount'] as codec.ClarityValueUInt).value;
+    const tokenId = (value.data['token-id'] as ClarityValueUInt).value;
+    const amount = (value.data['amount'] as ClarityValueUInt).value;
 
     return {
       tx_id: transaction.tx.txid,
@@ -430,8 +436,8 @@ export function getSmartContractDeployment(
   const sender = transaction.decoded.auth.origin_condition.signer.address;
   const payload = transaction.decoded.payload;
   if (
-    payload.type_id === codec.TxPayloadTypeID.SmartContract ||
-    payload.type_id === codec.TxPayloadTypeID.VersionedSmartContract
+    payload.type_id === TxPayloadTypeID.SmartContract ||
+    payload.type_id === TxPayloadTypeID.VersionedSmartContract
   ) {
     const principal = `${sender}.${payload.contract_name}`;
     return {


### PR DESCRIPTION
### Description

Two related maintenance changes for the pox-5 upgrade branch:

**1. Upgrade `@stacks/codec` `^1.6.0` → `^2.1.0`** for compatibility with the new Stacks pox-5 contract.

Codec 2.x ships as proper ESM with a real `export default` (the native binding functions). The repo imported it with a default import (`import codec from '@stacks/codec'`) and then accessed both decode functions *and* enums via `codec.*`. Under 1.6.0's CJS interop that default resolved to the full module namespace, so `codec.ClarityTypeID`, `codec.TxPayloadTypeID`, etc. worked at runtime. Under 2.x's ESM the default export contains **only** the decode functions — the enums are separate named exports — so `codec.TxPayloadTypeID` was `undefined` at runtime (`TypeError: Cannot read properties of undefined (reading 'SmartContract')`).

The subtle part: `tsc` passed clean either way, because TypeScript still typed the default import as the full namespace. The failure only surfaced at runtime, caught by the test suite.

Fixed by switching the five affected files to named imports of the specific symbols and types used:

- `src/token-processor/util/sip-validation.ts`
- `src/token-processor/stacks-node/stacks-node-rpc-client.ts`
- `src/token-processor/queue/job/update-token-supply-job.ts`
- `src/token-processor/queue/job/process-token-job.ts`
- `src/stacks-core/stacks-core-block-processor.ts`

The subsequent bump from 2.0.0 → 2.1.0 was a drop-in upgrade with no API changes and no further code edits.

**2. Pin all GitHub Actions to commit SHAs** in `.github/workflows/ci.yml` and `.github/workflows/release.yml`, hardening the CI/release supply chain. Each action is pinned to a full commit SHA with its version as a trailing comment, and bumped to its latest release in the process:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v6` | `@9c091bb` (v7.0.0) |
| `actions/setup-node` | `@v6` | `@48b55a0` (v6.4.0) |
| `actions/cache` | `@v5` | `@55cc834` (v6.1.0) |
| `codecov/codecov-action` | `@v5` | `@fb8b358` (v7.0.0) |
| `docker/setup-qemu-action` | `@v4` | `@96fe6ef` (v4.2.0) |
| `docker/setup-buildx-action` | `@v4` | `@bb05f3f` (v4.2.0) |
| `docker/metadata-action` | `@v6` | `@dc80280` (v6.2.0) |
| `docker/login-action` | `@v4` | `@af1e73f` (v4.4.0) |
| `docker/build-push-action` | `@v7` | `@53b7df9` (v7.3.0) |

#### Breaking change?

No. Internal-only changes; no public API or behavior changes.

### Checklist

- [x] All tests pass
- [ ] Tests added in this PR (if applicable)

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
