### PR TITLE
ci: fix release flow order and drop broken npm upgrade step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,36 +8,6 @@ on:
         type: string
 
 jobs:
-  publish-npm:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: v${{ inputs.version }}
-
-      - name: Use Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Upgrade npm
-        run: npm install -g npm@latest
-
-      - name: Install deps
-        run: npm ci --audit=false
-
-      - name: Install client deps
-        run: npm ci --audit=false
-        working-directory: client
-
-      - name: Publish client to npm
-        run: npm publish --provenance --access public
-        working-directory: client
-
   publish-docker:
     runs-on: ubuntu-latest
     permissions:
@@ -81,8 +51,37 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           push: true
 
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: publish-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Use Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install deps
+        run: npm ci --audit=false
+
+      - name: Install client deps
+        run: npm ci --audit=false
+        working-directory: client
+
+      - name: Publish client to npm
+        run: npm publish --provenance --access public
+        working-directory: client
+
   github-release:
     runs-on: ubuntu-latest
+    needs: publish-npm
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
### Description

Fixes the release workflow (`.github/workflows/release.yml`), which failed during the `publish-npm` step.

**1. Drop the broken `Upgrade npm` step.** The `publish-npm` job ran `npm install -g npm@latest` before publishing. Recent `npm@latest` ships a global install missing the bundled `sigstore` module that `npm publish --provenance` requires at runtime, so the publish died with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../libnpmpublish/lib/provenance.js
```

Rerunning was deterministic — same failure every time. The npm bundled with Node 24 (per `.nvmrc`) is already provenance-capable, so the manual upgrade was both unnecessary and the cause of the break. Removed it.

**2. Run the release jobs sequentially.** Previously `publish-npm`, `publish-docker`, and `github-release` ran as independent parallel jobs, so a GitHub release could be cut even if the docker/npm publishes failed. They now chain via `needs:`:

`publish-docker` → `publish-npm` → `github-release`

so the release is only created after both artifacts publish successfully.

#### Breaking change?

No. CI-only change; no application code or public API affected.

### Checklist

- [x] All tests pass
- [ ] Tests added in this PR (if applicable)

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
